### PR TITLE
Fix rolled back version

### DIFF
--- a/electrode-ota-server-model-app/src/app.js
+++ b/electrode-ota-server-model-app/src/app.js
@@ -425,7 +425,7 @@ export default (options, dao, upload, download) => {
                     rollout: 100,
                     releasedBy: params.email,
                     releaseMethod: "Rollback",
-                    originalLabel: rollback.label,
+                    originalLabel: rollto.label,
                     label: `v${history_.length + 1}`
                 });
                 return dao.addPackage(deployment.key, pkg).then(v => pkg);

--- a/electrode-ota-server-model-app/src/app.js
+++ b/electrode-ota-server-model-app/src/app.js
@@ -425,7 +425,7 @@ export default (options, dao, upload, download) => {
                     rollout: 100,
                     releasedBy: params.email,
                     releaseMethod: "Rollback",
-                    originalLabel: params.label,
+                    originalLabel: params.label || dpkg.label,
                     label: `v${history_.length + 1}`
                 });
                 return dao.addPackage(deployment.key, pkg).then(v => pkg);

--- a/electrode-ota-server-model-app/src/app.js
+++ b/electrode-ota-server-model-app/src/app.js
@@ -425,7 +425,7 @@ export default (options, dao, upload, download) => {
                     rollout: 100,
                     releasedBy: params.email,
                     releaseMethod: "Rollback",
-                    originalLabel: params.label || dpkg.label,
+                    originalLabel: rollback.label,
                     label: `v${history_.length + 1}`
                 });
                 return dao.addPackage(deployment.key, pkg).then(v => pkg);

--- a/electrode-ota-server-model-app/src/app.js
+++ b/electrode-ota-server-model-app/src/app.js
@@ -425,7 +425,7 @@ export default (options, dao, upload, download) => {
                     rollout: 100,
                     releasedBy: params.email,
                     releaseMethod: "Rollback",
-                    originalLabel: dpkg.label,
+                    originalLabel: params.label,
                     label: `v${history_.length + 1}`
                 });
                 return dao.addPackage(deployment.key, pkg).then(v => pkg);

--- a/electrode-ota-server-model-app/test/app-test.js
+++ b/electrode-ota-server-model-app/test/app-test.js
@@ -27,9 +27,9 @@ describe('model/app', function () {
         const up = upload({}, dao), down = download({}, dao);
         ac = appFactory({}, dao, up, (history) => diffPackageMap(down, up, history));
     });
-    
+
     after(shutdown);
-    
+
     it('should create/list/remove an app', () => {
         const email = 'test@p.com';
         return ac.createApp({email, name: 'super'})
@@ -340,7 +340,7 @@ describe('model/app', function () {
                     "isMandatory": true,
                     "label": "v3",
                     "originalDeployment": null,
-                    "originalLabel": "v2",
+                    "originalLabel": "v1",
                     "packageHash": "4e9518575422c9087396887ce20477ab5f550a4aa3d161c5c22a996b0abb8b35",
                     "releaseMethod": "Rollback",
                     "releasedBy": "test@p.com",
@@ -479,4 +479,3 @@ describe('model/app', function () {
 
 
 });
-

--- a/electrode-ota-server-model-app/test/app-test.js
+++ b/electrode-ota-server-model-app/test/app-test.js
@@ -252,7 +252,7 @@ describe('model/app', function () {
                     "label": "v3",
                     "originalDeployment": null,
                     "manifestBlobUrl": null,
-                    "originalLabel": "v2",
+                    "originalLabel": "v1",
                     "packageHash": "4e9518575422c9087396887ce20477ab5f550a4aa3d161c5c22a996b0abb8b35",
                     "blobUrl": "4e9518575422c9087396887ce20477ab5f550a4aa3d161c5c22a996b0abb8b35",
 


### PR DESCRIPTION
Say we have v1 and v2 deployments, and wish to roll back to v1.
Previously when running
```
code-push rollback code-push rollback <appName> <deploymentName> -r v1
```
it would roll back to v1 appropriately, but when viewing deployment history on v3 it would say
```
(Rolled back v2 to v2)
```
This was because `dpkg.label` is the newer version number (v2).  By replacing it with `params.label` (the input to -r) history now will properly say
```
(Rolled back v2 to v1)
```