### PR TITLE
Fix code-push patch

### DIFF
--- a/electrode-ota-server-model-app/src/app.js
+++ b/electrode-ota-server-model-app/src/app.js
@@ -227,7 +227,7 @@ export default (options, dao, upload, download) => {
                     description
                 };
 
-                return dao.updatePackage(deployment.key, npkg);
+                return dao.updatePackage(deployment.key, npkg, params.label);
             })).then(toJSON);
         },
 


### PR DESCRIPTION
Previously a patch would always update the oldest.  This happened whether or not a version was supplied contrary to the CLI saying (code-push path) 

> "--label, -l   Label of the release to update. Defaults to the latest release within the specified deployment".

With this change a patch updates the most recent version if no label is supplied (default behavior according to CLI).
It also updates the correct package when a label is provided.

**NOTE** I am a self proclaimed cassandra noob and don't know how to both use `id_: within(history_)` AND `label: label`.  That was not using, using `$in` syntax was not using, etc.  So I defaulted to what I know in JS, using lodash's filter.  It is working but I assume there is a more elegant way to do so.  I will feel no shame if you close this PR and implement it better yourself. 