### PR TITLE
Fix typos based on current package structure

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 Electrode OTA Server
 ===
-The Electrode OTA Server provides a server to allow hot deploy to android and ios React Native&#8482;  and Cordova&#8482;  apps.   The server 
-is API compatible with [code-push-cli](https://microsoft.github.io/code-push/docs/cli.html), the 
+The Electrode OTA Server provides a server to allow hot deploy to android and ios React Native&#8482;  and Cordova&#8482;  apps.   The server
+is API compatible with [code-push-cli](https://microsoft.github.io/code-push/docs/cli.html), the
 [Code Push React Native SDK](https://microsoft.github.io/code-push/docs/react-native.html) and the [Code Push Cordova SDK](https://microsoft.github.io/code-push/docs/cordova.html).
 
 
@@ -15,7 +15,7 @@ will happen automatically, unless the configuration to the electrode-ota-dao-cas
                     ...
                     "disableTTYConfirmation": false,
                     //this is alter by default.
-                    "migration: 'safe',
+                    "migration": "safe",
                 }
             }
  }

--- a/example-with-ui/config/development.json
+++ b/example-with-ui/config/development.json
@@ -8,7 +8,7 @@
         "keyspace": "ota_db_2"
       }
     },
-    "electrode-ota-server-fileservice": {
+    "electrode-ota-server-fileservice-upload": {
       "options": {
         "downloadUrl": "http://localhost.walmart.com:9001/storagev2/"
       }
@@ -66,4 +66,3 @@
     }
   }
 }
-


### PR DESCRIPTION
- Some quotes in the readme not accurate
- Fix incorrect plugin name in example development.json 

This may close issue #13