### PR TITLE
Fall back to username if no email available

### DIFF
--- a/electrode-ota-server-model-account/src/account.js
+++ b/electrode-ota-server-model-account/src/account.js
@@ -47,7 +47,7 @@ export default function (options, dao) {
 
         createToken({profile = {}, provider, query = {}}) {
 
-            const email = profile.email;
+            const email = profile.email || profile.username;
             const ak = genAccessKey({email, createdBy: query.hostname});
             const accessKeys = {[ak.name]: ak};
             const account = {

--- a/electrode-ota-server-model-account/src/account.js
+++ b/electrode-ota-server-model-account/src/account.js
@@ -36,7 +36,6 @@ export default function (options, dao) {
         },
 
         async addAccessKey(email, createdBy, friendlyName, ttl) {
-            email = email || username;
             const ak = genAccessKey({email, createdBy, friendlyName, ttl});
             const user = await  dao.userByEmail(email);
 

--- a/electrode-ota-server-routes-accesskeys/src/index.js
+++ b/electrode-ota-server-routes-accesskeys/src/index.js
@@ -27,9 +27,9 @@ export const register = diregister({
             config: {
                 handler(request, reply){
 
-                    const {auth: {credentials: {email, name}}, payload = {}, params: {key}} = request;
+                    const {auth: {credentials: {email, name, username}}, payload = {}, params: {key}} = request;
                     //email, createdBy, friendlyName, ttl
-                    addAccessKey(email || name, request.connection.info.host, payload.friendlyName, payload.ttl, (e, accessKey) => {
+                    addAccessKey(email || username, request.connection.info.host, payload.friendlyName, payload.ttl, (e, accessKey) => {
                         if (e) return reply(e);
                         const {createdBy, friendlyName, description, name, createdTime, expires} = accessKey;
                         reply({

--- a/electrode-ota-server-routes-auth/src/index.js
+++ b/electrode-ota-server-routes-auth/src/index.js
@@ -143,7 +143,7 @@ export const register = diregister({
                             const {email, displayName, username} = credentials.profile;
                             const {hostname} = credentials.query || {};
                             //(email, createdBy, friendlyName, ttl
-                            addAccessKey(email, hostname, displayName || username, void(0), (e, token) => {
+                            addAccessKey(email || username, hostname, displayName, void(0), (e, token) => {
                                 if (e) {
                                     console.error('Error adding key', e);
                                     return reply.view('error', {


### PR DESCRIPTION
This PR makes it so `code-push register` works using username in place of email when no email is available.

This is a scenario I ran into with the way our github enterprise is configured. 

It also fixes a bug where username is referenced when not defined 