### PR TITLE
Allow code-push rollback with no label

### DIFF
--- a/electrode-ota-server-routes-apps/src/index.js
+++ b/electrode-ota-server-routes-apps/src/index.js
@@ -337,9 +337,6 @@ export const register = diregister({
             method: 'POST',
             path: '/apps/{app}/deployments/{deployment}/rollback/{label?}',
             config: {
-                validate: {
-                    params: Object.assign({label: Joi.string()}, PARAMS.deployment)
-                },
                 payload: Object.assign({}, options.payload),
                 handler(request, reply)
                 {

--- a/electrode-ota-server-routes-apps/src/index.js
+++ b/electrode-ota-server-routes-apps/src/index.js
@@ -337,6 +337,9 @@ export const register = diregister({
             method: 'POST',
             path: '/apps/{app}/deployments/{deployment}/rollback/{label?}',
             config: {
+                validate: {
+                  params: PARAMS.deployment
+                },
                 payload: Object.assign({}, options.payload),
                 handler(request, reply)
                 {


### PR DESCRIPTION
Fix CLI error around rollback with no label attribute (should default to prior release)

```
$ code-push rollback MyApp Staging
Are you sure? (y/N): y
[Error]  child "label" fails because ["label" is not allowed to be empty]
```
becomes
```
$ code-push rollback MyApp Staging
Are you sure? (y/N): y
Successfully performed a rollback on the "Staging" deployment of the "CaribouIOS" app.
```

This sheds light on a bug though.  As

`$ code-push deployment h MyApp Staging` creates a new version, say v6, stating `(Rolled back v5 to v5)`
