### PR TITLE
--hot flag already adds HotModuleReplacementPlugin

### DIFF
--- a/electrode-ota-ui/webpack.config.js
+++ b/electrode-ota-ui/webpack.config.js
@@ -114,8 +114,6 @@ var config = {
 };
 if (isHot) {
 	
-	config.plugins.unshift(new webpack.HotModuleReplacementPlugin());
-	config.devServer.hot = true;
 	config.entry = [
 		'react-hot-loader/patch',
 		// activate HMR for React


### PR DESCRIPTION
Use of the --hot flag already adds HotModuleReplacementPlugin.   Adding it again will cause issues.