### PR TITLE
update download() function to return content and length.

### DIFF
--- a/electrode-ota-server-fileservice-download/src/index.js
+++ b/electrode-ota-server-fileservice-download/src/index.js
@@ -14,12 +14,19 @@ export const fileservice = (options, dao) => {
             || url.split('/').pop();
         const p = dao.download(hash);
 
-        if (type == 'application/json') {
-            p.then((resp) => {
-                return JSON.parse(resp + '')
-            });
-        }
-        return p;
+        return p.then((resp) => {
+            if (type == 'application/json') {
+                return {
+                    content: JSON.parse(resp + ''),
+                    length: resp.length
+                };
+            } else {
+                return {
+                    content: resp,
+                    length: resp.length
+                };
+            }
+        });
     };
 };
 export const register = diregister({
@@ -28,4 +35,3 @@ export const register = diregister({
     connections: false,
     dependencies: ['ota!dao']
 }, fileservice);
-

--- a/electrode-ota-server-model-acquisition/test/acquisition-test.js
+++ b/electrode-ota-server-model-acquisition/test/acquisition-test.js
@@ -1,11 +1,11 @@
-import initDao, {shutdown} from 'electrode-ota-server-test-support/lib/init-dao';
+import initDao, { shutdown } from 'electrode-ota-server-test-support/lib/init-dao';
 import acquisition from 'electrode-ota-server-model-acquisition/lib/acquisition';
-import {loggerFactory} from 'electrode-ota-server-logger';
-import {fileservice as uploadFactory} from 'electrode-ota-server-fileservice-upload';
-import {fileservice as downloadFactory} from 'electrode-ota-server-fileservice-download';
-import {diffPackageMapCurrent} from 'electrode-ota-server-model-manifest/lib/manifest';
+import { loggerFactory } from 'electrode-ota-server-logger';
+import { fileservice as uploadFactory } from 'electrode-ota-server-fileservice-upload';
+import { fileservice as downloadFactory } from 'electrode-ota-server-fileservice-download';
+import { diffPackageMapCurrent } from 'electrode-ota-server-model-manifest/lib/manifest';
 import appFactory from 'electrode-ota-server-model-app/lib/app';
-import {expect} from 'chai';
+import { expect } from 'chai';
 
 describe('model/acquisition', function () {
     let ac;
@@ -25,7 +25,7 @@ describe('model/acquisition', function () {
         const logger = loggerFactory({});
         const manifest = diffPackageMapCurrent.bind(null, download, upload);
         ac = acquisition({}, dao, genRatio, download, manifest, logger);
-        appBL = appFactory({}, dao, upload, download, logger)
+        appBL = appFactory({}, dao, upload, logger);
     });
     after(shutdown);
 
@@ -33,8 +33,8 @@ describe('model/acquisition', function () {
         it('should be 50% rollout', () => {
             const result = [];
             const update = (uniqueClientId = 'uniqueClientId',
-                            packageHash = 'packageHash',
-                            ratio = 50) => () => ac.isUpdateAble(uniqueClientId, packageHash, ratio).then(r => result.push(r));
+                packageHash = 'packageHash',
+                ratio = 50) => () => ac.isUpdateAble(uniqueClientId, packageHash, ratio).then(r => result.push(r));
             const first = update();
             return first().then(first).then(first).then(_ => {
                 const [r0, r1, r2] = result;
@@ -83,16 +83,16 @@ describe('model/acquisition', function () {
                 package: 'stuff-stuff-stuff-stuff-stuff',
                 deployment: 'Staging',
                 packageInfo: {
-                  description: 'release without tags initially',
-                  rollout: 100
+                    description: 'release without tags initially',
+                    rollout: 100
                 }
             }).then(() => {
                 return ac.updateCheck({
-                    deploymentKey : stagingKey,
-                    appVersion : '1.0.0',
-                    packageHash : 'junk',
-                    isCompanion : false,
-                    label : 'v0',
+                    deploymentKey: stagingKey,
+                    appVersion: '1.0.0',
+                    packageHash: 'junk',
+                    isCompanion: false,
+                    label: 'v0',
                     clientUniqueId
                 }).then((result) => {
                     expect(result).not.to.be.undefined;
@@ -132,7 +132,7 @@ describe('model/acquisition', function () {
                 email,
                 package: 'even-more-stuff-stuff-stuff-stuff-stuff',
                 deployment: 'Staging',
-                packageInfo : {
+                packageInfo: {
                     description: 'Got some tags',
                     tags: ['TAG-1', 'TAG-2']
                 }

--- a/electrode-ota-server-model-app/src/app.js
+++ b/electrode-ota-server-model-app/src/app.js
@@ -78,7 +78,7 @@ const notAuthorizedPerm = (app, email, perm, message) => {
   return notAuthorized(false, message);
 };
 
-export default (options, dao, upload, download, logger) => {
+export default (options, dao, upload, logger) => {
   const api = {};
   return Object.assign(api, {
     findApp({ email, app }) {
@@ -265,7 +265,7 @@ export default (options, dao, upload, download, logger) => {
               notFound(
                 pkg,
                 `Deployment "${params.deployment}" has no package with label "${
-                  params.label
+                params.label
                 }"`
               );
             }
@@ -277,9 +277,9 @@ export default (options, dao, upload, download, logger) => {
               alreadyExistsMsg(
                 existingPackage.packageHash !== pkg.packageHash,
                 `Deployment ${params.deployment}:${
-                  pkg.label
+                pkg.label
                 } has already been promoted to ${params.to}:${
-                  existingPackage.label
+                existingPackage.label
                 }.`
               );
             }

--- a/electrode-ota-server-model-app/src/index.js
+++ b/electrode-ota-server-model-app/src/index.js
@@ -5,6 +5,5 @@ export const register = diregister({
     name: 'ota!app',
     multiple: false,
     connections: false,
-    dependencies: ['ota!dao', 'ota!fileservice-upload', 'ota!fileservice-download', 'ota!logger']
+    dependencies: ['ota!dao', 'ota!fileservice-upload', 'ota!logger']
 }, app);
-

--- a/electrode-ota-server-model-app/test/app-test.js
+++ b/electrode-ota-server-model-app/test/app-test.js
@@ -7,7 +7,6 @@ import fs from "fs";
 import appFactory from "electrode-ota-server-model-app/lib/app";
 import accountFactory from "electrode-ota-server-model-account/lib/account";
 import { fileservice as upload } from "electrode-ota-server-fileservice-upload";
-import { fileservice as download } from "electrode-ota-server-fileservice-download";
 import { manifestHash } from "electrode-ota-server-model-manifest/lib/manifest";
 import { shasum } from "electrode-ota-server-util";
 import { expect } from "chai";
@@ -24,20 +23,18 @@ const APP = {
   app: "super"
 };
 
-describe("model/app", function() {
+describe("model/app", function () {
   this.timeout(50000);
   let account, ac;
   before(async () => {
     const dao = await initDao();
     let w = 0;
     account = accountFactory({}, dao, console);
-    const up = upload({}, dao),
-      down = download({}, dao);
+    const up = upload({}, dao);
     ac = appFactory(
       {},
       dao,
       up,
-      history => diffPackageMap(down, up, history),
       console
     );
   });
@@ -728,8 +725,8 @@ describe("model/app", function() {
           email,
           package: readFixture("step.0.blob.zip"),
           deployment: "Staging",
-          packageInfo : {
-            description : "release with tags",
+          packageInfo: {
+            description: "release with tags",
             tags,
           }
         }).then((newPkg) => {
@@ -750,14 +747,14 @@ describe("model/app", function() {
     return ac
       .createApp({ email, name: appName })
       .then(() => ac.upload({
-          app: appName,
-          email,
-          package: readFixture("step.0.blob.zip"),
-          deployment: "Staging",
-          packageInfo: {
-            description: "release without tags"
-          }
-        }))
+        app: appName,
+        email,
+        package: readFixture("step.0.blob.zip"),
+        deployment: "Staging",
+        packageInfo: {
+          description: "release without tags"
+        }
+      }))
       .then(() => ac.promoteDeployment({
         app: appName,
         email,
@@ -800,7 +797,7 @@ describe("model/app", function() {
         expect(updated.tags).not.to.be.undefined;
         expect(updated.tags.length).to.eq(tags.length);
         expect(updated.tags.indexOf(tags[0])).to.be.gte(0);
-        expect(updated.tags.indexOf(tags[1])).to.be.gte(0);      
+        expect(updated.tags.indexOf(tags[1])).to.be.gte(0);
       });
   });
 });

--- a/electrode-ota-server-routes-acquisition/src/index.js
+++ b/electrode-ota-server-routes-acquisition/src/index.js
@@ -50,9 +50,8 @@ export const register = diregister({
                     logger.info(reqFields(request), "download request");
                     download(request.params.packageHash, (e, o) => {
                         if (e) return reply(e);
-                        streamToBuf(o).then((buf) => {
-                            reply(buf).type("application/octet-stream").bytes(buf.length);
-                        });
+                        const { content, length } = o;
+                        reply(content).type("application/octet-stream").bytes(length);
                     });
                 },
                 tags: ["api"]

--- a/electrode-ota-server-service-fileservice/src/index.js
+++ b/electrode-ota-server-service-fileservice/src/index.js
@@ -3,5 +3,5 @@ export const register = diregister({
     name: "ota!fileservice",
     multiple: false,
     connections: false,
-    dependencies: ['ota!fileservice-upload', 'ota!fileservice-download']
-}, (options, upload)=> upload);
+    dependencies: ['ota!fileservice-upload']
+}, (options, upload) => upload);


### PR DESCRIPTION
Because of the need to return the Content-Length header, we need a download's content and length.  Update service-download to return length and content.

Remove reference to service-download from  electrode-ota-server-service-fileservice,  electrode-ota-server-model-app.  Not needed in those projects.