### PR TITLE
if client version is higher, then no update available

### DIFF
--- a/electrode-ota-server-model-acquisition/src/acquisition.js
+++ b/electrode-ota-server-model-acquisition/src/acquisition.js
@@ -36,7 +36,8 @@ export default (options, dao, weighted, _download, manifest, logger) => {
 
                 pkg = await dao.getNewestApplicablePackage(params.deploymentKey, params.tags);
 
-                let isNotAvailable = pkg.packageHash == params.packageHash || !('clientUniqueId' in params);
+                let isNotAvailable = pkg.packageHash == params.packageHash || !('clientUniqueId' in params)
+                        || version.gt(params.appVersion, pkg.appVersion);
 
                 const appVersion = fixver(pkg.appVersion);
 
@@ -51,6 +52,7 @@ export default (options, dao, weighted, _download, manifest, logger) => {
                         packageSize,
                         packageHash: pkg.packageHash,
                         description: pkg.description,
+                        // true == there is an update but it requires a newer binary version.
                         "updateAppVersion": version.lt(fixver(params.appVersion), appVersion),
                         //TODO - find out what this should be
                         "shouldRunBinaryVersion": false

--- a/electrode-ota-server-model-acquisition/test/acquisition-test.js
+++ b/electrode-ota-server-model-acquisition/test/acquisition-test.js
@@ -196,5 +196,27 @@ describe('model/acquisition', function () {
                 });
             });
         });
+
+        it('no update if package version is greater than latest package', () => {
+            return appBL.upload({
+                app: name,
+                email,
+                package: 'Some awesome package content',
+                deployment: 'Staging',
+                packageInfo: {
+                    description: 'Some content'
+                }
+            }).then((pkg) => {
+                expect(pkg.appVersion).to.eql('1.0.0');
+                return ac.updateCheck({
+                    deploymentKey: stagingKey,
+                    appVersion: '1.0.1',
+                    packageHash: 'ABCD',
+                    clientUniqueId
+                }).then((result) => {
+                    expect(result.isAvailable).to.eq(false);
+                });
+            });
+        });
     });
 });


### PR DESCRIPTION
If the client version is higher than the available package, then return no update available.