### PR TITLE
Fix UI metric for staging

### DIFF
--- a/electrode-ota-ui/src/pages/Deployment/index.js
+++ b/electrode-ota-ui/src/pages/Deployment/index.js
@@ -71,8 +71,8 @@ const mapDispatchToProps = (dispatch, pps) => {
 		onClearDeploymentHistory(){
 			return _dispatch(clearDeploymentHistory, this);
 		},
-		onGetDeploymentMetrics(){
-			return _dispatch(getDeploymentMetrics, this);
+		onGetDeploymentMetrics(value){
+			return _dispatch(getDeploymentMetrics, this, value);
 		},
 		onGetDeploymentHistory(value){
 			return _dispatch(getDeploymentHistory, this, value);


### PR DESCRIPTION
Fix issue where UI was only showing Production metrics, even if you are on the Staging view.  It was because it was not passing the environment (`value` field) to the server call.