### PR TITLE
fix patch to update from appropriate version

### DIFF
--- a/electrode-ota-server-model-app/test/app-test.js
+++ b/electrode-ota-server-model-app/test/app-test.js
@@ -804,64 +804,133 @@ describe("model/app", function () {
   it("should updateDeployment for a label", () => {
     const email = "label@walmart.com";
     const appName = "updateDeploymentWithLabel";
-    return ac.createApp({email, name: appName })
-    .then(() => ac.upload({
-      app:appName,
-      email,
-      package: "Package for v1",
-      deployment: "Staging",
-      packageInfo: {
-        description: "v1 description",
+    return ac.createApp({ email, name: appName })
+      .then(() => ac.upload({
+        app: appName,
+        email,
+        package: "Package for v1",
+        deployment: "Staging",
+        packageInfo: {
+          description: "v1 description",
+          label: "v1",
+          rollout: 10,
+          isDisabled: false
+        }
+      }))
+      .then(() => ac.upload({
+        app: appName,
+        email,
+        package: "Package v2",
+        deployment: "Staging",
+        packageInfo: {
+          description: "v2 description",
+          label: "v2",
+          isDisabled: false,
+          rollout: 11
+        }
+      }))
+      .then(() => ac.updateDeployment({
+        app: appName,
+        email,
+        description: "v1 new description",
+        deployment: "Staging",
         label: "v1",
-        rollout: 10,
-        isDisabled: false
-      }
-    }))
-    .then(() => ac.upload({
-      app: appName,
-      email,
-      package: "Package v2",
-      deployment: "Staging",
-      packageInfo: {
-        description: "v2 description",
-        label: "v2",
-        isDisabled: false,
-        rollout: 11
-      }
-    }))
-    .then(() => ac.updateDeployment({
-      app:appName,
-      email,
-      description: "v1 new description",
-      deployment: "Staging",
-      label: "v1",
-      rollout: 99,
-      isDisabled: true
-    }))
-    .then((updated) => {
-      expect(updated).not.to.be.undefined;
-      expect(updated.label).to.eq("v1");
-      expect(updated.isDisabled).to.be.true;
-      expect(updated.rollout).to.eq(99);
-      expect(updated.description).to.eq("v1 new description");
-    })
-    .then(() => ac.historyDeployment({
-      app: appName,
-      email,
-      deployment: "Staging"
-    }))
-    .then((history) => {
-      expect(history.length).to.eq(2);
-      const v1 = history[1];
-      expect(v1.label).to.eq("v1");
-      expect(v1.isDisabled).to.be.true;
-      expect(v1.rollout).to.eq(99);
-      expect(v1.description).to.eq("v1 new description");
-      const v2 = history[0];
-      expect(v2.label).to.eq("v2");
-      expect(v2.isDisabled).to.be.false;
-      expect(v2.rollout).to.eq(11);
-      expect(v2.description).to.eq("v2 description");
-    })
+        rollout: 99,
+        isDisabled: true
+      }))
+      .then((updated) => {
+        expect(updated).not.to.be.undefined;
+        expect(updated.label).to.eq("v1");
+        expect(updated.isDisabled).to.be.true;
+        expect(updated.rollout).to.eq(99);
+        expect(updated.description).to.eq("v1 new description");
+      })
+      .then(() => ac.historyDeployment({
+        app: appName,
+        email,
+        deployment: "Staging"
+      }))
+      .then((history) => {
+        expect(history.length).to.eq(2);
+        const v1 = history[1];
+        expect(v1.label).to.eq("v1");
+        expect(v1.isDisabled).to.be.true;
+        expect(v1.rollout).to.eq(99);
+        expect(v1.description).to.eq("v1 new description");
+        const v2 = history[0];
+        expect(v2.label).to.eq("v2");
+        expect(v2.isDisabled).to.be.false;
+        expect(v2.rollout).to.eq(11);
+        expect(v2.description).to.eq("v2 description");
+      })
   });
+
+  it("updateDeployment should not copy from latest", () => {
+    const email = "joesmoe@walmart.com";
+    const appName = "updateDeployementDoesNotCopy";
+
+    return ac.createApp({ email, name: appName })
+      .then(() => ac.upload({
+        app: appName,
+        email,
+        package: "v1 Package",
+        deployment: "Staging",
+        packageInfo: {
+          description: "v1 description to be modified",
+          label: "v1",
+          rollout: 1,
+          isDisabled: true,
+          isMandatory: true,
+          appVersion: "1.0.0",
+          tags: ["blue"]
+        }
+      }))
+      .then(() => ac.upload({
+        app: appName,
+        email,
+        package: "v2 Package",
+        deployment: "Staging",
+        packageInfo: {
+          description: "v2 description",
+          label: "v2",
+          rollout: 99,
+          isDisabled: false,
+          isMandatory: false,
+          appVersion: "2.0.0",
+          tags: ["red"]
+        }
+      }))
+      .then(() => ac.updateDeployment({
+        app: appName,
+        email,
+        deployment: "Staging",
+        label: "v1",
+        description: "v1 new description"
+      }))
+      .then((updated) => {
+        expect(updated.label).to.eq("v1");
+        expect(updated.description).to.eq("v1 new description");
+        expect(updated.rollout).to.eq(1);
+        expect(updated.isDisabled).to.be.true;
+        expect(updated.isMandatory).to.be.true;
+        expect(updated.appVersion).to.eq("1.0.0");
+        expect(updated.tags).to.have.members(["blue"]);
+      })
+      .then(() => ac.historyDeployment({
+        app: appName,
+        email,
+        deployment: "Staging"
+      }))
+      .then((history) => {
+        expect(history.length).to.eq(2);
+        const v1 = history[1];
+        expect(v1.label).to.eq("v1");
+        expect(v1.description).to.eq("v1 new description");
+        expect(v1.rollout).to.eq(1);
+        expect(v1.isDisabled).to.be.true;
+        expect(v1.isMandatory).to.be.true;
+        expect(v1.appVersion).to.eq("1.0.0");
+        expect(v1.tags).to.have.members(["blue"]);
+      })
+  })
 });


### PR DESCRIPTION
code-push patch was using the latest version when updating an older package.  this fix is to ensure it uses the correct version if a label is specified.