### PR TITLE
Delay SQL tests run to give time for db tables creation

### DIFF
--- a/electrode-ota-mariadb-schema/sql-tests/run-tests.sh
+++ b/electrode-ota-mariadb-schema/sql-tests/run-tests.sh
@@ -3,6 +3,9 @@
 CLEANUP=/tests/cleanup.sql
 TESTS=/tests/tests.sql
 
+echo "sleeping for 5 sec while seeding database"
+sleep 5s
+
 echo "executing cleanup sql"
 mysql --user=${MYSQL_USER} --password=${MYSQL_PASSWORD} ${MYSQL_DATABASE} < ${CLEANUP}
 rc=$?


### PR DESCRIPTION
Add a little delay (5 secs) before running the database tests, to make sure that the database tables have been properly created.

Without doing this, running the `test.sh` script from [electrode-ota-maria-db](https://github.com/electrode-io/electrode-ota-server/tree/master/electrode-ota-mariadb-schema) fails consistently on my workstation (see logs below).

Seems like the tests are immediately started once the `ota-db` container is reachable and at this point, the tables are now fully created yet.

There is probably a better solution, but this one does the job in a simple way. 

```
$ ./test.sh
Building ota-db
Step 1/1 : FROM mariadb:10.3
 ---> f0b6a295092e
Successfully built f0b6a295092e
Successfully tagged electrodeotamariadbschema_ota-db:latest
Building liquibase
Step 1/2 : FROM webdevops/liquibase:mysql
 ---> 5df18c6ab716
Step 2/2 : ENTRYPOINT ["/common/wait-for-it.sh", "ota-db:3306", "--", "/entrypoint"]
 ---> Using cache
 ---> a3fe436edc0f
Successfully built a3fe436edc0f
Successfully tagged electrodeotamariadbschema_liquibase:latest
Creating network "electrodeotamariadbschema_default" with the default driver
Creating electrodeotamariadbschema_ota-db_1 ... done
Creating electrodeotamariadbschema_liquibase_1 ... done
wait-for-it.sh: waiting 15 seconds for ota-db:3306
wait-for-it.sh: ota-db:3306 is available after 6 seconds
executing cleanup sql
ERROR 1146 (42S02) at line 2: Table 'electrode_ota.metric' doesn't exist
error during cleanup; exiting
tests failed!
Stopping electrodeotamariadbschema_liquibase_1 ... done
Stopping electrodeotamariadbschema_ota-db_1    ... done
Removing electrodeotamariadbschema_liquibase_1 ... done
Removing electrodeotamariadbschema_ota-db_1    ... done
Removing network electrodeotamariadbschema_default
done
```

