### PR TITLE
Fix acquisition when package hash is missing

### DIFF
--- a/electrode-ota-server-model-acquisition/src/acquisition.js
+++ b/electrode-ota-server-model-acquisition/src/acquisition.js
@@ -59,7 +59,7 @@ export default (options, dao, weighted, _download, manifest, logger) => {
                         "shouldRunBinaryVersion": false
                     };
                     if (isAvailable) {
-                        if (pkg.manifestBlobUrl) {
+                        if (pkg.manifestBlobUrl && params.packageHash) {
                             const diffPackageMap = pkg.diffPackageMap || {};
                             const partial = diffPackageMap[params.packageHash];
                             if (partial) {


### PR DESCRIPTION
While doing some testing on Android, using an Electrode OTA server instance running locally on my machine, from current master, I noticed an issue in `updateCheck` acquisition function, leading to an HTTP 500 internal server error when trying to acquire a new package.

1) Push new pkg1 to server
2) Launch Android app. updateCheck OK. Android app properly retrieves pkg1 (Going from binary bundle => pkg1).
3) Push new pkg2 to server.
4) Launch Android app. updateCheck OK. Android app properly retrieves pkg2 (Going from pkg1 => pkg2)
5) Uninstall Android app and reinstall it from scratch, then launch it. While it should go from binary bundle => pkg2, updateCheck is failing with internal server error.

The error happens because of the [insertPackageContent](https://github.com/electrode-io/electrode-ota-server/blob/v4.4.7/electrode-ota-server-dao-mariadb/src/queries/PackageContentQueries.ts#L9) SQL request that is failing due to same package hash (primary key) already existing. This is because for some reason, with the current code, when the `packageHash` query parameter has no value when calling `updateCheck`, the code reaches [this point](https://github.com/electrode-io/electrode-ota-server/blob/master/electrode-ota-server-model-acquisition/src/acquisition.js#L73) apparently creating a diff of latest package v.s installed package. The problem here is that in the case of a missing `packageHash` param, the latest package and installed package are the same for some reason, leading to creating a diff between two identical packages. This happens because in step 2) above, the packageHash is missing leading to the creation of a diff file with no diff, and hashed. Then in step 5 the same is done, leading to the same diff hash.

Anyway, I can see that these modifications were done in recent PR https://github.com/electrode-io/electrode-ota-server/pull/68, to fix issue https://github.com/electrode-io/electrode-ota-server/issues/66. This current PR still works for https://github.com/electrode-io/electrode-ota-server/issues/66 as in the logs provided we can see that a hash exists.

For Android, when a new native application version is installed on the phone, the first time `updateCheck` will be called, will always be with an empty/missing packageHash query parameter, due to some [technical restriction](https://github.com/Microsoft/react-native-code-push/blob/master/CodePush.js#L68-L72). Therefore, an empty `packageHash` means "I am running this native application for the first time, so I have not yet downloaded any update". In that case, the latest available package for this version should be returned, which is what is done by short-circuiting the `if` block.

Tested with same scenario, and working fine with this fix.

You should not run `4.4.7` on Production as it will lead to this issue for Android updates.