### PR TITLE
On updateCheck, find latest package that matches specified appVersion

### DIFF
--- a/electrode-ota-server-dao-mariadb/src/ElectrodeOtaDaoRdbms.ts
+++ b/electrode-ota-server-dao-mariadb/src/ElectrodeOtaDaoRdbms.ts
@@ -204,9 +204,10 @@ export default class ElectrodeOtaDaoRdbms implements IElectrodeOtaDao {
     }
 
     public async getNewestApplicablePackage(deploymentKey: string,
-                                            tags: string[] | undefined): Promise<PackageDTO | void> {
+                                            tags: string[] | undefined,
+                                            appVersion: string | undefined): Promise<PackageDTO | void> {
         return this.connectAndExecute<PackageDTO | void>((conection) => {
-            return PackageDAO.getNewestApplicablePackage(conection, deploymentKey, tags);
+            return PackageDAO.getNewestApplicablePackage(conection, deploymentKey, tags, appVersion);
         });
     }
 

--- a/electrode-ota-server-dao-mariadb/src/IElectrodeOtaDao.ts
+++ b/electrode-ota-server-dao-mariadb/src/IElectrodeOtaDao.ts
@@ -35,7 +35,7 @@ export interface IElectrodeOtaDao {
     packageById(packageId: number): Promise<PackageDTO>;
     addPackage(deploymentKey: string, packageInfo: PackageDTO): Promise<PackageDTO>;
     updatePackage(deploymentKey: string, packageInfo: any, label: string): Promise<PackageDTO>;
-    getNewestApplicablePackage(deploymentKey: string, tags: string[] | undefined): Promise<PackageDTO | void>;
+    getNewestApplicablePackage(deploymentKey: string, tags: string[] | undefined, appVersion: string | undefined): Promise<PackageDTO | void>;
 
     history(appId: number, deploymentName: string): Promise<PackageDTO[]>;
     historyByIds(historyIds: number[]): Promise<PackageDTO[]>;

--- a/electrode-ota-server-dao-mariadb/src/dao/PackageDAO.ts
+++ b/electrode-ota-server-dao-mariadb/src/dao/PackageDAO.ts
@@ -62,17 +62,27 @@ export default class PackageDAO extends BaseDAO {
     }
 
     public static async getNewestApplicablePackage(connection: IConnection, deploymentKey: string,
-        tags: string[] | undefined): Promise<PackageDTO | void> {
+        tags: string[] | undefined, appVersion: string | undefined): Promise<PackageDTO | void> {
 
         const deployment = await DeploymentDAO.deploymentForKey(connection, deploymentKey);
         const deploymentId = deployment.id;
 
-        const query = (tags && tags.length > 0) ? PackageQueries.getMostRecentPackageIdByDeploymentAndTags :
-            PackageQueries.getMostRecentPackageIdByDeploymentNoTags;
-
-        const params = (tags && tags.length > 0) ? [deploymentId, tags, deploymentId] : [deploymentId];
-
-        const result = await PackageDAO.query(connection, query, params);
+        const useTags = tags && tags.length > 0 ? "tags" : "notags";
+        const useVersion = appVersion !== undefined ? "version" : "noversion";
+        const allQueries:{[key:string]: string;} = {
+            "tags-noversion": PackageQueries.getMostRecentPackageIdByDeploymentAndTags,
+            "notags-noversion": PackageQueries.getMostRecentPackageIdByDeploymentNoTags,
+            "tags-version": PackageQueries.getMostRecentPackageIdByDeploymentAndTagsAndVersion,
+            "notags-version": PackageQueries.getMostRecentPackageIdByDeploymentNoTagsAndVersion
+        }
+        const allParams:{[key:string]:any} = {
+            "tags-noversion": [deploymentId, tags, deploymentId],
+            "notags-noversion": [deploymentId],
+            "tags-version": [deploymentId, appVersion, tags, deploymentId],
+            "notags-version": [deploymentId, appVersion]
+        }
+        const key = `${useTags}-${useVersion}`;
+        const result = await PackageDAO.query(connection, allQueries[key], allParams[key]);
 
         if (result && result.length > 0) {
             return await PackageDAO.packageById(connection, result[0].package_id);

--- a/electrode-ota-server-dao-mariadb/src/queries/PackageQueries.ts
+++ b/electrode-ota-server-dao-mariadb/src/queries/PackageQueries.ts
@@ -38,11 +38,41 @@ export const PackageQueries = {
                                     WHERE dph.package_id = pt.package_id)
 
                                     ORDER BY 2 DESC`,
+    getMostRecentPackageIdByDeploymentAndTagsAndVersion : `SELECT dph.package_id, p.create_time
+                                    FROM deployment_package_history dph, package_tag pt, package p
+                                    WHERE dph.deployment_id = ?
+                                    AND p.id = dph.package_id
+                                    AND p.app_version = ?
+                                    AND dph.package_id = pt.package_id
+                                    AND pt.tag_name IN (?)
 
+                                    UNION
+
+                                    SELECT dph.package_id, p.create_time
+                                    FROM deployment_package_history dph, package p
+                                    WHERE dph.deployment_id = ?
+                                    AND dph.package_id = p.id
+                                    AND NOT EXISTS
+                                    (SELECT 1
+                                    FROM package_tag pt
+                                    WHERE dph.package_id = pt.package_id)
+
+                                    ORDER BY 2 DESC`,
     getMostRecentPackageIdByDeploymentNoTags : `SELECT dph.package_id, p.create_time
                                                 FROM deployment_package_history dph, package p
                                                 WHERE dph.deployment_id = ?
                                                 AND dph.package_id = p.id
+                                                AND NOT EXISTS
+                                                (SELECT 1
+                                                FROM package_tag pt
+                                                WHERE dph.package_id = pt.package_id)
+
+                                                ORDER BY 2 DESC`,
+    getMostRecentPackageIdByDeploymentNoTagsAndVersion : `SELECT dph.package_id, p.create_time
+                                                FROM deployment_package_history dph, package p
+                                                WHERE dph.deployment_id = ?
+                                                AND dph.package_id = p.id
+                                                AND p.app_version = ?
                                                 AND NOT EXISTS
                                                 (SELECT 1
                                                 FROM package_tag pt

--- a/electrode-ota-server-dao-plugin/test/dao-cassandra-test.js
+++ b/electrode-ota-server-dao-plugin/test/dao-cassandra-test.js
@@ -371,6 +371,91 @@ describe('dao/cassandra', function () {
                 });
             });
         });
+        it("will return a release matching specified appVersion", () => {
+            const versionToCheck = "1.1.0";
+            const v1pkg = Object.assign({}, pkg1, {
+              appVersion: versionToCheck,
+              packageHash: "2930fj2j923892f9h9f831899182889hf",
+              label: "v1"
+            });
+            const v2pkg = Object.assign({}, v1pkg, {
+              appVersion: "1.2.0",
+              packageHash: "ABCDEFG",
+              label: "v2"
+            });
+            return dao
+              .addPackage(stagingKey, v1pkg)
+              .then(() => {
+                return dao.addPackage(stagingKey, v2pkg);
+              })
+              .then(() => {
+                return dao
+                  .getNewestApplicablePackage(stagingKey, [], versionToCheck)
+                  .then(release => {
+                    expect(release).not.be.undefined;
+                    expect(release.packageHash).to.eq(v1pkg.packageHash);
+                  });
+              });
+        });
+        it("will return latest release matching specified appVersion", () => {
+            const versionToCheck = "1.3.0";
+            const v1apkg = Object.assign({}, pkg1, {
+              appVersion: versionToCheck,
+              packageHash: "ABCDEF1234",
+              label: "v1"
+            });
+            const v1bpkg = Object.assign({}, v1apkg, {
+              appVersion: versionToCheck,
+              packageHash: "ABCDEF7890",
+              label: "v2"
+            });
+            const v2pkg = Object.assign({}, v1apkg, {
+              appVersion: "1.4.0",
+              packageHash: "EDCBA44321",
+              label: "v3"
+            });
+            return dao
+              .addPackage(stagingKey, v1apkg)
+              .then(() => {
+                return dao.addPackage(stagingKey, v1bpkg);
+              })
+              .then(() => {
+                return dao.addPackage(stagingKey, v2pkg);
+              })
+              .then(() => {
+                return dao
+                  .getNewestApplicablePackage(stagingKey, [], versionToCheck)
+                  .then(release => {
+                    expect(release).not.be.undefined;
+                    expect(release.packageHash).to.eq(v1bpkg.packageHash);
+                  });
+              });
+        });
+        it("will return undefined for unmatched appVersion", () => {
+            const versionToCheck = "1.8.0";
+            const v1pkg = Object.assign({}, pkg1, {
+              appVersion: "1.7.0",
+              packageHash: "ACEBDF135246",
+              label: "v1"
+            });
+            const v2pkg = Object.assign({}, pkg1, {
+              appVersion: "1.9.0",
+              packageHash: "A1C3E5B2D4F6",
+              label: "v2"
+            });
+            return dao
+              .addPackage(stagingKey, v1pkg)
+              .then(() => {
+                return dao.addPackage(stagingKey, v2pkg);
+              })
+              .then(() => {
+                return dao
+                  .getNewestApplicablePackage(stagingKey, [], versionToCheck)
+                  .then(release => {
+                    expect(release).to.be.undefined;
+                  });
+              });
+        });
     });
 });
 

--- a/electrode-ota-server-model-acquisition/src/acquisition.js
+++ b/electrode-ota-server-model-acquisition/src/acquisition.js
@@ -34,7 +34,19 @@ export default (options, dao, weighted, _download, manifest, logger) => {
                     }
                 }
 
-                pkg = await dao.getNewestApplicablePackage(params.deploymentKey, params.tags);
+                pkg = await dao.getNewestApplicablePackage(params.deploymentKey, params.tags, params.appVersion);
+
+                if(!pkg) {
+                    // no package match, use latest version that matches tag
+                    pkg = await dao.getNewestApplicablePackage(params.deploymentKey, params.tags);
+                    if (!pkg) {
+                        // no package matching tag
+                        return {
+                            isAvailable: false,
+                            shouldRunBinaryVersion: false
+                        }
+                    }
+                }
 
                 let isNotAvailable = pkg.packageHash == params.packageHash || !('clientUniqueId' in params)
                     || version.gt(params.appVersion, pkg.appVersion)

--- a/electrode-ota-server-model-acquisition/test/acquisition-test.js
+++ b/electrode-ota-server-model-acquisition/test/acquisition-test.js
@@ -195,6 +195,43 @@ describe('model/acquisition', function () {
             });
         });
 
+        it('pick the appropriate package for the given appversion', () => {
+            let pkg1_1, pkg1_2;
+            return appBL.upload({
+                app: name,
+                email,
+                package: 'Package Content v1.0.0 goes here',
+                deployment: 'Staging',
+                packageInfo: {
+                    description: 'Content for v1.0.0',
+                    appVersion: '1.0.0'
+                }
+            }).then((pkg) => {
+                pkg1_1 = pkg;
+                return appBL.upload({
+                    app: name,
+                    email,
+                    package: 'Package Content v1.2.0 goes here',
+                    deployment: 'Staging',
+                    packageInfo: {
+                        description: 'Content for v1.2.0',
+                        appVersion: '1.2.0'
+                    }
+                })
+            }).then((pkg) => {
+                pkg1_2 = pkg;
+                return ac.updateCheck({
+                    deploymentKey: stagingKey,
+                    appVersion: '1.0.0',
+                    packageHash: 'ABCD',
+                    clientUniqueId
+                });
+            }).then((result) => {
+                expect(result.isAvailable).to.be.true;
+                expect(result.packageHash).to.eq(pkg1_1.packageHash);
+            })
+        });
+
         it('no update if package is disabled', () => {
             return appBL.upload({
                 app: name,


### PR DESCRIPTION
Given two binary versions, with the same bundle IDs.
Version v1.1.0 . bundleHash ABC . label v1
Version v1.2.0 . bundleHash ABC . label v2

A new bundle is released to both binary versions
Version v1.1.0 . bundleHash DEF . label v3
Version v1.2.0 . bundleHash DEF . label v4

When mobile clients on version v1.1.0 check for updates..
Expected: return package label v3.
Actual: returns "update not available".  this is because we don't search using the appVersion.