### PR TITLE
Update .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,8 +16,8 @@ addons:
 
 before_install:
   - java -version
-  - wget http://www.us.apache.org/dist/cassandra/3.11.4/apache-cassandra-3.11.4-bin.tar.gz && tar -xvzf apache-cassandra-3.11.4-bin.tar.gz
-  - sudo sh ./apache-cassandra-3.11.4/bin/cassandra -R
+  - wget http://mirrors.gigenet.com/apache/cassandra/3.11.5/apache-cassandra-3.11.5-bin.tar.gz && tar -xvzf apache-cassandra-3.11.5-bin.tar.gz
+  - sudo sh ./apache-cassandra-3.11.5/bin/cassandra -R
   - sleep 20
 
 script:


### PR DESCRIPTION
A broken link to a cassandra archive file in `.travis.yml` caused the CI to fail. This is an attempt to fix it.

To be merged before #108