### PR TITLE
Relax node engine restriction

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "electrode-ota-server": "./index.js"
   },
   "engines": {
-    "node": "^8.16.0"
+    "node": ">=8.16"
   },
   "keywords": ["code-push", "ota", "electrode", "react-native", "cordova"],
   "dependencies": {


### PR DESCRIPTION
Allow Node.js versions **greater than or equal** to `8.16`, instead of only `^8.16.0`.

Node.js 8 will reach [end of life in December 2019](https://nodejs.org/en/about/releases/).

The **active LTS** versions are Node.js 10 and Node.js 12, and the current version is Node.js 13. Unless there are strong reasons, we should not artificially restrict this project to a Node version that will soon be obsolete.