### PR TITLE
CodePush definition update changes in Electrode OTA Server

### DIFF
--- a/electrode-ota-server-model-acquisition/src/acquisition.js
+++ b/electrode-ota-server-model-acquisition/src/acquisition.js
@@ -141,8 +141,7 @@ export default (options, dao, weighted, _download, manifest, logger) => {
             metric.status = "Downloaded";
             return dao.insertMetric(metric)
                 .tap(() => logger.info({ depoymentKey: metric.deploymentKey, label: metric.label }, "recorded download success"));
-        }
-        ,
+        },
         /**
          * {
 	"appVersion": "1.0.0",

--- a/electrode-ota-server-model-acquisition/src/acquisition.js
+++ b/electrode-ota-server-model-acquisition/src/acquisition.js
@@ -1,5 +1,9 @@
-import { missingParameter } from 'electrode-ota-server-errors';
-import version from 'semver';
+/* eslint-disable max-params */
+import { missingParameter } from "electrode-ota-server-errors";
+import version from "semver";
+
+const ZERO = 0;
+const HUNDRED = 100;
 
 export default (options, dao, weighted, _download, manifest, logger) => {
     const api = {
@@ -9,6 +13,9 @@ export default (options, dao, weighted, _download, manifest, logger) => {
 
         /**
          *  https://codepush.azurewebsites.net/updateCheck?deploymentKey=5UfjnOxv1FnCJ_DwPqMWQYSVlp0H4yecGHaB-&appVersion=1.2.3&packageHash=b10064ba007b3857655726404972980f963879fa4fe196b1ef9d06ae6d3891d5&isCompanion=&label=&clientUniqueId=4B4CBBF7-7F0A-4D34-BD9A-984FD190766D
+         * @param {Object} params as query-string Object
+         * @returns {Object} data-object
+         *
          * param deploymentKey
          * param appVersion
          * param packageHash
@@ -30,11 +37,11 @@ export default (options, dao, weighted, _download, manifest, logger) => {
                     return {
                         isAvailable: false,
                         shouldRunBinaryVersion: false
-                    }
+                    };
                 }
 
                 pkg = await dao.getNewestApplicablePackage(params.deploymentKey, params.tags, params.appVersion);
-                if(!pkg) {
+                if (!pkg) {
                     // no package match, use latest version that matches tag
                     pkg = await dao.getNewestApplicablePackage(params.deploymentKey, params.tags);
                     if (!pkg) {
@@ -42,16 +49,17 @@ export default (options, dao, weighted, _download, manifest, logger) => {
                         return {
                             isAvailable: false,
                             shouldRunBinaryVersion: false
-                        }
+                        };
                     }
                 }
                 const pkgAppVersion = version.coerce(pkg.appVersion, true).toString();
                 const paramAppVersion = version.coerce(params.appVersion, true).toString();
 
-                let isNotAvailable = pkg.packageHash == params.packageHash || !('clientUniqueId' in params)
+                const isNotAvailable = pkg.packageHash == params.packageHash || !("clientUniqueId" in params)
                     || version.gt(paramAppVersion, pkgAppVersion)
                     || pkg.isDisabled;
 
+                // eslint-disable-next-line func-style
                 function makeReturn(isAvailable) {
                     const packageSize = pkg && pkg.size && (pkg.size - 0) || 0;
                     const ret = {
@@ -64,9 +72,9 @@ export default (options, dao, weighted, _download, manifest, logger) => {
                         packageHash: pkg.packageHash,
                         description: pkg.description,
                         // true == there is an update but it requires a newer binary version.
-                        "updateAppVersion": version.lt(paramAppVersion, pkgAppVersion),
+                        updateAppVersion: version.lt(paramAppVersion, pkgAppVersion),
                         //TODO - find out what this should be
-                        "shouldRunBinaryVersion": false
+                        shouldRunBinaryVersion: false
                     };
                     if (isAvailable) {
                         if (pkg.manifestBlobUrl && params.packageHash) {
@@ -81,7 +89,7 @@ export default (options, dao, weighted, _download, manifest, logger) => {
                                     .then(history => history.filter(v => v.packageHash == params.packageHash))
                                     .then(matches => {
                                         // No packages match params.packageHash;  return existing package
-                                        if(matches.length == 0) {
+                                        if (matches.length === ZERO) {
                                             return ret;
                                         }
                                         // manifest generates the diff between latest package and client's package
@@ -89,6 +97,7 @@ export default (options, dao, weighted, _download, manifest, logger) => {
                                             const newPackage = v[v.length - 1];
                                             // TODO: Offload generating a diff map to another process.
                                             // Save package diff created from manifest
+                                            // eslint-disable-next-line max-nested-callbacks
                                             return dao.addPackageDiffMap(deployment.key, newPackage, params.packageHash).then(() => {
                                                 const p2 = newPackage.diffPackageMap && newPackage.diffPackageMap[params.packageHash];
                                                 if (p2) {
@@ -112,7 +121,7 @@ export default (options, dao, weighted, _download, manifest, logger) => {
                     makeReturn(!isNotAvailable) :
                     api.isUpdateAble(params.clientUniqueId, pkg.packageHash, pkg.rollout, pkg.tags).then(makeReturn);
 
-            }).tap((res) => {
+            }).tap(res => {
                 logger.info({
                     event: {
                         name: "checkedForUpdate",
@@ -129,7 +138,7 @@ export default (options, dao, weighted, _download, manifest, logger) => {
                               deploymentKey,
                               label
                               }*/ metric) {
-            metric.status = 'Downloaded';
+            metric.status = "Downloaded";
             return dao.insertMetric(metric)
                 .tap(() => logger.info({ depoymentKey: metric.deploymentKey, label: metric.label }, "recorded download success"));
         }
@@ -166,11 +175,11 @@ export default (options, dao, weighted, _download, manifest, logger) => {
          * the last roll of the die.
          * Otherwise roll the die and save the results so if we get asked again...
          *
-         * @param uniqueClientId
-         * @param packageHash
-         * @param ratio
-         * @param tags
-         * @returns {*}
+         * @param {String} uniqueClientId unique-client identifier
+         * @param {String} packageHash unique name for the package as hash
+         * @param {String} ratio given ratio
+         * @param {String} tags the tag
+         * @returns {*} data-object
          */
         isUpdateAble(uniqueClientId, packageHash, ratio, tags) {
             // if the package has tags, the rollout will not be taken into account;
@@ -180,17 +189,17 @@ export default (options, dao, weighted, _download, manifest, logger) => {
             }
 
             //ratio 0 means no deployment.
-            if (ratio == 0) {
+            if (ratio === ZERO) {
                 return Promise.resolve(false);
             }
             //ratio null well shouldn't be so we'll do true.
-            if (ratio == 100 || ratio == null) {
+            if (ratio === HUNDRED || ratio == null) {
                 return Promise.resolve(true);
             }
 
             return dao.clientRatio(uniqueClientId, packageHash).then(resp => {
                 //if the ratio is the same just return the last decision;
-                if (resp && resp.ratio == ratio) {
+                if (resp && resp.ratio === ratio) {
                     return resp.updated;
                 }
                 const updated = weighted(ratio);

--- a/electrode-ota-server-routes-acquisition/src/index.js
+++ b/electrode-ota-server-routes-acquisition/src/index.js
@@ -37,6 +37,22 @@ export const register = diregister({
         });
     };
 
+    const handleReportDeployStatus = (request, reply) => {
+        logger.info(reqFields(request), "report deployment status request");
+        const snakeCaseRequested = /report_status/.test(request.url.path);
+        // if snake_case request? convert to camelCase
+        const payload = snakeCaseRequested ? keysToCamelOrSnake(request.payload) : request.payload;
+        deployReportStatus(payload, ok(reply));
+    };
+
+    const handleReportDownloadStatus = (request, reply) => {
+        logger.info(reqFields(request), "report download status request");
+        const snakeCaseRequested = /report_status/.test(request.url.path);
+        // if snake_case request? convert to camelCase
+        const payload = snakeCaseRequested ? keysToCamelOrSnake(request.payload) : request.payload;
+        downloadReportStatus(request.payload, ok(reply));
+    };
+
     route([
         {
             method: "GET",
@@ -77,10 +93,16 @@ export const register = diregister({
             method: "POST",
             config: {
                 auth: false,
-                handler(request, reply) {
-                    logger.info(reqFields(request), "report deployment status request");
-                    deployReportStatus(request.payload, ok(reply));
-                },
+                handler: handleReportDeployStatus,
+                tags: ["api"]
+            }
+        },
+        {
+            path: "/report_status/deploy",
+            method: "POST",
+            config: {
+                auth: false,
+                handler: handleReportDeployStatus,
                 tags: ["api"]
             }
         },
@@ -89,10 +111,16 @@ export const register = diregister({
             method: "POST",
             config: {
                 auth: false,
-                handler(request, reply) {
-                    logger.info(reqFields(request), "report download status request");
-                    downloadReportStatus(request.payload, ok(reply));
-                },
+                handler: handleReportDownloadStatus,
+                tags: ["api"]
+            }
+        },
+        {
+            path: "/report_status/download",
+            method: "POST",
+            config: {
+                auth: false,
+                handler: handleReportDownloadStatus,
                 tags: ["api"]
             }
         }

--- a/electrode-ota-server-routes-acquisition/src/index.js
+++ b/electrode-ota-server-routes-acquisition/src/index.js
@@ -33,8 +33,6 @@ export const register = diregister({
             }
             // if snake_case request? convert the response to the same
             const updateInfo = snakeCaseRequested ? keysToCamelOrSnake(updatedInfo) : updatedInfo;
-            console.log(request.url.path);
-            console.log({ updateInfo });
             reply({ updateInfo });
         });
     };

--- a/electrode-ota-server-routes-acquisition/src/index.js
+++ b/electrode-ota-server-routes-acquisition/src/index.js
@@ -22,8 +22,9 @@ export const register = diregister({
     } = wrap(acquisition);
 
     const handleUpdateCheck = (request, reply) => {
-        logger.info(reqFields(request), "updateCheck request");
-        const snakeCaseRequested = /update_check/.test(request.url.path);
+        const action = request.url.pathname;
+        logger.info(reqFields(request), `${action} request`);
+        const snakeCaseRequested = /update_check/.test(action);
         // if snake_case request? convert to camelCase
         const qs = snakeCaseRequested ? keysToCamelOrSnake(request.query) : request.query;
         updateCheck(qs, (e, updatedInfo) => {
@@ -38,19 +39,21 @@ export const register = diregister({
     };
 
     const handleReportDeployStatus = (request, reply) => {
-        logger.info(reqFields(request), "report deployment status request");
-        const snakeCaseRequested = /report_status/.test(request.url.path);
+        const action = request.url.pathname;
+        logger.info(reqFields(request), `report deployment status request ${action}`);
+        const snakeCaseRequested = /report_status/.test(action);
         // if snake_case request? convert to camelCase
         const payload = snakeCaseRequested ? keysToCamelOrSnake(request.payload) : request.payload;
         deployReportStatus(payload, ok(reply));
     };
 
     const handleReportDownloadStatus = (request, reply) => {
-        logger.info(reqFields(request), "report download status request");
-        const snakeCaseRequested = /report_status/.test(request.url.path);
+        const action = request.url.pathname;
+        logger.info(reqFields(request), `report download status request ${action}`);
+        const snakeCaseRequested = /report_status/.test(action);
         // if snake_case request? convert to camelCase
         const payload = snakeCaseRequested ? keysToCamelOrSnake(request.payload) : request.payload;
-        downloadReportStatus(request.payload, ok(reply));
+        downloadReportStatus(payload, ok(reply));
     };
 
     route([

--- a/electrode-ota-server-routes-acquisition/src/keys-to-camel-or-snake.js
+++ b/electrode-ota-server-routes-acquisition/src/keys-to-camel-or-snake.js
@@ -1,0 +1,29 @@
+import toCamelCase from "./to-camel-case";
+import toSnakeCase from "./to-snake-case";
+
+const isValidObject = o => {
+    if (o === Object(o) && o !== null && !Array.isArray(o) && typeof o !== "function") {
+      return Object.keys(o).length > 0;
+    }
+
+    return false;
+};
+
+const keysToCamelOrSnake = o => {
+    if (isValidObject(o)) {
+      // find if the keys to convert cameCase or snake_case
+      const keys = Object.keys(o);
+      const keyConverter = /([_][a-z])/i.test(keys[0]) ? toCamelCase : toSnakeCase;
+      // now apply the key-converter
+      const n = {};
+      keys.forEach(k => {
+          n[keyConverter(k)] = keysToCamelOrSnake(o[k]);
+      });
+
+      return n;
+    }
+
+    return o;
+};
+
+export default keysToCamelOrSnake;

--- a/electrode-ota-server-routes-acquisition/src/to-camel-case.js
+++ b/electrode-ota-server-routes-acquisition/src/to-camel-case.js
@@ -1,0 +1,11 @@
+// convert snake/pascal case to camelCase
+const toCamelCase = s => {
+    // include "-" to line#5 convert hyphenated-vars to camelCase
+    // also this .replace("-", "") to line#7
+    return s.replace(/([_][a-z])/ig, $1 => {
+      return $1.toUpperCase()
+        .replace("_", "");
+    });
+};
+
+export default toCamelCase;

--- a/electrode-ota-server-routes-acquisition/src/to-snake-case.js
+++ b/electrode-ota-server-routes-acquisition/src/to-snake-case.js
@@ -1,0 +1,7 @@
+// convert from camelCase to snake-case
+const toSnakeCase = s => {
+    return s.replace(/\.?([A-Z]+)/g, (x, y) => `_${ y.toLowerCase()}`)
+            .replace(/^_/, "");
+};
+
+export default toSnakeCase;

--- a/electrode-ota-server/test/electrode-ota-server-test.js
+++ b/electrode-ota-server/test/electrode-ota-server-test.js
@@ -107,7 +107,7 @@ describe('electrode-ota-server', function () {
             label: "",
             client_unique_id: "76451410-77F2-423C-836C-623AA5F586B5"
         }
-    }, body("OK")));
+    }, match(/OK/)));
 
     it('should respond to newly updated service "/report_status/download" with modified params', request({
         method: 'POST',
@@ -120,8 +120,6 @@ describe('electrode-ota-server', function () {
             label: "",
             client_unique_id: "76451410-77F2-423C-836C-623AA5F586B5"
         }
-    }, (response) => {
-        console.log(response);
-    }));
+    }, match(/OK/)));
 });
 

--- a/electrode-ota-server/test/electrode-ota-server-test.js
+++ b/electrode-ota-server/test/electrode-ota-server-test.js
@@ -78,7 +78,7 @@ describe('electrode-ota-server', function () {
         }
     })));
 
-    it('should respond to newly updated service "/updated_check" with modified params', request({
+    it('should respond to newly updated service "/update_check" with modified params', request({
         url: '/update_check?deployment_key=evHVNrwuJDVdTvpSouLxKpEyowtcxyWcyVCxnsFD&app_version=1.2.3&package_hash=&is_companion=&label=&client_unique_id=76451410-77F2-423C-836C-623AA5F586B5'
     }, body({
         updateInfo: {
@@ -87,8 +87,8 @@ describe('electrode-ota-server', function () {
         }
     })));
 
-    it('should respond with old response structure for "/updateCheck" service even if "updated_check=true" is in parameters', request({
-        url: '/update_check?deployment_key=evHVNrwuJDVdTvpSouLxKpEyowtcxyWcyVCxnsFD&app_version=1.2.3&package_hash=&is_companion=&label=&client_unique_id=76451410-77F2-423C-836C-623AA5F586B5'
+    it('should respond with old/existing response structure for "/updateCheck" service even if "update_check=true" is in parameters', request({
+        url: '/updateCheck?update_check=true&deployment_key=evHVNrwuJDVdTvpSouLxKpEyowtcxyWcyVCxnsFD&app_version=1.2.3&package_hash=&is_companion=&label=&client_unique_id=76451410-77F2-423C-836C-623AA5F586B5'
     }, body({
         updateInfo: {
             isAvailable: false,
@@ -99,13 +99,27 @@ describe('electrode-ota-server', function () {
     it('should respond to newly updated service "/report_status/deploy" with modified params', request({
         method: 'POST',
         url: '/report_status/deploy',
-        body: {"deployment_key": "evHVNrwuJDVdTvpSouLxKpEyowtcxyWcyVCxnsFD", "app_version": "1.2.3","package_hash":"","is_companion":"", "label": "", "client_unique_id": "76451410-77F2-423C-836C-623AA5F586B5"}
+        payload: {
+            deployment_key: "evHVNrwuJDVdTvpSouLxKpEyowtcxyWcyVCxnsFD",
+            app_version: "1.2.3",
+            package_hash:"",
+            is_companion:"",
+            label: "",
+            client_unique_id: "76451410-77F2-423C-836C-623AA5F586B5"
+        }
     }, body("OK")));
 
     it('should respond to newly updated service "/report_status/download" with modified params', request({
         method: 'POST',
         url: '/report_status/download',
-        body: {"deployment_key": "evHVNrwuJDVdTvpSouLxKpEyowtcxyWcyVCxnsFD", "app_version": "1.2.3","package_hash":"","is_companion":"", "label": "", "client_unique_id": "76451410-77F2-423C-836C-623AA5F586B5"}
+        payload: {
+            deployment_key: "evHVNrwuJDVdTvpSouLxKpEyowtcxyWcyVCxnsFD",
+            app_version: "1.2.3",
+            package_hash:"",
+            is_companion:"",
+            label: "",
+            client_unique_id: "76451410-77F2-423C-836C-623AA5F586B5"
+        }
     }, body("OK")));
 });
 

--- a/electrode-ota-server/test/electrode-ota-server-test.js
+++ b/electrode-ota-server/test/electrode-ota-server-test.js
@@ -78,5 +78,12 @@ describe('electrode-ota-server', function () {
         }
     })));
 
-
+    it('should respond to newly updated directive "/updated_check" with modified params', request({
+        url: '/update_check?deployment_key=evHVNrwuJDVdTvpSouLxKpEyowtcxyWcyVCxnsFD&app_version=1.2.3&package_hash=&is_companion=&label=&client_unique_id=76451410-77F2-423C-836C-623AA5F586B5'
+    }, body({
+        updateInfo: {
+            is_available: false,
+            should_run_binary_version: false
+        }
+    })));
 });

--- a/electrode-ota-server/test/electrode-ota-server-test.js
+++ b/electrode-ota-server/test/electrode-ota-server-test.js
@@ -86,4 +86,26 @@ describe('electrode-ota-server', function () {
             should_run_binary_version: false
         }
     })));
+
+    it('should respond with old response structure for "/updateCheck" service even if "updated_check=true" is in parameters', request({
+        url: '/update_check?deployment_key=evHVNrwuJDVdTvpSouLxKpEyowtcxyWcyVCxnsFD&app_version=1.2.3&package_hash=&is_companion=&label=&client_unique_id=76451410-77F2-423C-836C-623AA5F586B5'
+    }, body({
+        updateInfo: {
+            isAvailable: false,
+            shouldRunBinaryVersion: false
+        }
+    })));
+
+    it('should respond to newly updated service "/report_status/deploy" with modified params', request({
+        method: 'POST',
+        url: '/report_status/deploy',
+        body: {"deployment_key": "evHVNrwuJDVdTvpSouLxKpEyowtcxyWcyVCxnsFD", "app_version": "1.2.3","package_hash":"","is_companion":"", "label": "", "client_unique_id": "76451410-77F2-423C-836C-623AA5F586B5"}
+    }, body("OK")));
+
+    it('should respond to newly updated service "/report_status/download" with modified params', request({
+        method: 'POST',
+        url: '/report_status/download',
+        body: {"deployment_key": "evHVNrwuJDVdTvpSouLxKpEyowtcxyWcyVCxnsFD", "app_version": "1.2.3","package_hash":"","is_companion":"", "label": "", "client_unique_id": "76451410-77F2-423C-836C-623AA5F586B5"}
+    }, body("OK")));
 });
+

--- a/electrode-ota-server/test/electrode-ota-server-test.js
+++ b/electrode-ota-server/test/electrode-ota-server-test.js
@@ -78,7 +78,7 @@ describe('electrode-ota-server', function () {
         }
     })));
 
-    it('should respond to newly updated directive "/updated_check" with modified params', request({
+    it('should respond to newly updated service "/updated_check" with modified params', request({
         url: '/update_check?deployment_key=evHVNrwuJDVdTvpSouLxKpEyowtcxyWcyVCxnsFD&app_version=1.2.3&package_hash=&is_companion=&label=&client_unique_id=76451410-77F2-423C-836C-623AA5F586B5'
     }, body({
         updateInfo: {

--- a/electrode-ota-server/test/electrode-ota-server-test.js
+++ b/electrode-ota-server/test/electrode-ota-server-test.js
@@ -88,7 +88,7 @@ describe('electrode-ota-server', function () {
     })));
 
     it('should respond with old/existing response structure for "/updateCheck" service even if "update_check=true" is in parameters', request({
-        url: '/updateCheck?update_check=true&deployment_key=evHVNrwuJDVdTvpSouLxKpEyowtcxyWcyVCxnsFD&app_version=1.2.3&package_hash=&is_companion=&label=&client_unique_id=76451410-77F2-423C-836C-623AA5F586B5'
+        url: '/updateCheck?update_check=true&deploymentKey=evHVNrwuJDVdTvpSouLxKpEyowtcxyWcyVCxnsFD&appVersion=1.2.3&packageHash=&isCompanion=&label=&clientUniqueId=76451410-77F2-423C-836C-623AA5F586B5'
     }, body({
         updateInfo: {
             isAvailable: false,
@@ -120,6 +120,8 @@ describe('electrode-ota-server', function () {
             label: "",
             client_unique_id: "76451410-77F2-423C-836C-623AA5F586B5"
         }
-    }, body("OK")));
+    }, (response) => {
+        console.log(response);
+    }));
 });
 


### PR DESCRIPTION
CodePush definition update for the new Service
source: https://github.com/microsoft/code-push/pull/645/files

The changes here responds to new `/update_check`, `/report_status/deploy`, `/report_status/download` services, all with new set of parameters(modified the queries to camelCase to snake_case).

Still the existing `/updateCheck`, `/reportStatus/deploy`, `/reportStatus/download` services are supported as well.