### PR TITLE
add real-time data to metrics-summary

### DIFF
--- a/electrode-ota-server-model-app/src/app.js
+++ b/electrode-ota-server-model-app/src/app.js
@@ -1,3 +1,5 @@
+/* eslint-disable max-params */
+/* eslint-disable max-statements */
 import { id, key, toJSON } from "electrode-ota-server-util";
 import { isZip, generate, manifestHash } from "electrode-ota-server-model-manifest/lib/manifest";
 import { shasum } from "electrode-ota-server-util";
@@ -73,6 +75,54 @@ const notAuthorizedPerm = (app, email, perm, message) => {
     return app;
   }
   return notAuthorized(false, message);
+};
+
+const doSummarize = (metrics, label) => {
+  const summary = metrics.reduce((accumulator, val) => {
+    const akey = val.label || val.appversion;
+    const ret =
+      accumulator[akey] ||
+      (accumulator[akey] = {
+        active: 0,
+        downloaded: 0,
+        installed: 0,
+        failed: 0
+      });
+    switch (val.status) {
+      case "DeploymentSucceeded":
+        ret.active += val.total;
+        if (label === val.label) {
+          //previous deployment is no longer active.
+          if (accumulator[val.previouslabelorappversion]) {
+            accumulator[val.previouslabelorappversion].active -= val.total;
+          } else {
+            // metrics is not ordered, so previous label not necessary in accumulator yet
+            accumulator[val.previouslabelorappversion] = {
+              active: -val.total,
+              downloaded: 0,
+              installed: 0,
+              failed: 0
+            };
+          }
+        }
+        ret.installed += val.total;
+        break;
+      case "DeploymentFailed":
+        ret.failed += val.total;
+        break;
+      case "Downloaded":
+        ret.downloaded += val.total;
+        break;
+    }
+    return accumulator;
+  }, {});
+  for (const k in summary) {
+    // Zero out negative active counts.
+    // Negative counts can occur if the previous active < current active
+    summary[k].active = summary[k].active > 0 ? summary[k].active : 0;
+  }
+
+  return summary;
 };
 
 export default (options, dao, upload, logger) => {
@@ -523,7 +573,23 @@ export default (options, dao, upload, logger) => {
     getMetricsForDeployment(deployment) {
       return this.getMetricsFromCache(deployment).then(result => {
         if (result && result.summaryJson) {
-          return JSON.parse(result.summaryJson);
+          const summary = JSON.parse(result.summaryJson);
+          // fetch latest metrics data
+          return dao.metricsByStatusAndTime(
+            deployment.key, new Date(result.lastRunTimeUTC), new Date(Date.now())
+          ).then((metrics = []) => {
+            const { label } = deployment.package || {};
+            logger.info({ deployment: deployment.name }, "fetched latest metrics by status and time");
+            // cleanup and merge the results
+            const latestSummary = doSummarize(metrics, label);
+            for (const k in summary) {
+              summary[k].active += latestSummary[k].active;
+              summary[k].downloaded += latestSummary[k].downloaded;
+              summary[k].failed += latestSummary[k].failed;
+              summary[k].installed += latestSummary[k].installed;
+            }
+            return summary;
+          });
         }
         return this.getMetricsFromDatabase(deployment);
       });
@@ -542,51 +608,7 @@ export default (options, dao, upload, logger) => {
         //    "DeploymentSucceeded" |  "DeploymentFailed" |  "Downloaded";
 
         logger.info({ deployment: deployment.name }, "fetched metrics by status");
-
-        let summary = metrics.reduce((accumulator, val) => {
-          const key = val.label || val.appversion;
-          const ret =
-            accumulator[key] ||
-            (accumulator[key] = {
-              active: 0,
-              downloaded: 0,
-              installed: 0,
-              failed: 0
-            });
-          switch (val.status) {
-            case "DeploymentSucceeded":
-              ret.active += val.total;
-              if (label === val.label) {
-                //previous deployment is no longer active.
-                if (accumulator[val.previouslabelorappversion]) {
-                  accumulator[val.previouslabelorappversion].active -= val.total;
-                } else {
-                  // metrics is not ordered, so previous label not necessary in accumulator yet
-                  accumulator[val.previouslabelorappversion] = {
-                    active: -val.total,
-                    downloaded: 0,
-                    installed: 0,
-                    failed: 0
-                  };
-                }
-              }
-              ret.installed += val.total;
-              break;
-            case "DeploymentFailed":
-              ret.failed += val.total;
-              break;
-            case "Downloaded":
-              ret.downloaded += val.total;
-              break;
-          }
-          return accumulator;
-        }, {});
-        for (let k in summary) {
-          // Zero out negative active counts.
-          // Negative counts can occur if the previous active < current active
-          summary[k].active = summary[k].active > 0 ? summary[k].active : 0;
-        }
-        return summary;
+        return doSummarize(metrics, label);
       });
     },
 

--- a/electrode-ota-server-model-app/src/app.js
+++ b/electrode-ota-server-model-app/src/app.js
@@ -77,6 +77,13 @@ const notAuthorizedPerm = (app, email, perm, message) => {
   return notAuthorized(false, message);
 };
 
+const isValidObject = obj => {
+  if (obj !== null && typeof obj === "object") {
+    return Object.keys(obj).length >= 1;
+  }
+  return false;
+};
+
 const doSummarize = (metrics, label) => {
   const summary = metrics.reduce((accumulator, val) => {
     const akey = val.label || val.appversion;
@@ -582,11 +589,13 @@ export default (options, dao, upload, logger) => {
             logger.info({ deployment: deployment.name }, "fetched latest metrics by status and time");
             // cleanup and merge the results
             const latestSummary = doSummarize(metrics, label);
-            for (const k in summary) {
-              summary[k].active += latestSummary[k].active;
-              summary[k].downloaded += latestSummary[k].downloaded;
-              summary[k].failed += latestSummary[k].failed;
-              summary[k].installed += latestSummary[k].installed;
+            if (isValidObject(latestSummary)) {
+              for (const k in summary) {
+                summary[k].active += latestSummary[k].active;
+                summary[k].downloaded += latestSummary[k].downloaded;
+                summary[k].failed += latestSummary[k].failed;
+                summary[k].installed += latestSummary[k].installed;
+              }
             }
             return summary;
           });

--- a/electrode-ota-server-model-app/src/app.js
+++ b/electrode-ota-server-model-app/src/app.js
@@ -590,13 +590,17 @@ export default (options, dao, upload, logger) => {
             // cleanup and merge the results
             const latestSummary = doSummarize(metrics, label);
             if (isValidObject(latestSummary)) {
-              for (const k in summary) {
+              for (const k in latestSummary) {
+                if (!summary[k]) {
+                  summary[k] = { active: 0, downloaded: 0, failed: 0, installed: 0 };
+                }
                 summary[k].active += latestSummary[k].active;
                 summary[k].downloaded += latestSummary[k].downloaded;
                 summary[k].failed += latestSummary[k].failed;
                 summary[k].installed += latestSummary[k].installed;
               }
             }
+
             return summary;
           });
         }

--- a/electrode-ota-server-model-app/test/app-test.js
+++ b/electrode-ota-server-model-app/test/app-test.js
@@ -1,3 +1,4 @@
+/* eslint-disable max-statements */
 import initDao, { shutdown } from "electrode-ota-server-test-support/lib/init-maria-dao";
 import eql from "electrode-ota-server-test-support/lib/eql";
 import path from "path";
@@ -15,6 +16,7 @@ const fixture = path.join.bind(path, __dirname, "fixtures");
 const readFixture = file => fs.readFileSync(fixture(file));
 
 const shouldError = () => {
+  // eslint-disable-next-line no-unused-expressions
   expect(false, "Should have an error").to.be.true;
 };
 const APP = {
@@ -83,8 +85,8 @@ describe("model/app", function() {
       .then(apps => expect(apps.length).to.eql(0));
   });
   it("should add/rename/remove deployment", () => {
-    const email = "deployment@p.com",
-      app = "deployment";
+    const email = "deployment@p.com";
+    const app = "deployment";
     return createAccount(email, "deploy")
       .then(() => ac.createApp({ email, name: "deployment" }))
       .then(_ => ac.listDeployments({ email, app }))
@@ -351,8 +353,8 @@ describe("model/app", function() {
   it("allow promote of same bundle for different app versions", () => {
     const email = "swaggychamp@gmail.com";
     const appName = "allowSameBundleDifferentAppVersion";
-    let firstLabel = "",
-      secondLabel = "";
+    let firstLabel = "";
+    let secondLabel = "";
     return createAccount(email, "champ")
       .then(() => ac.createApp({ email, name: appName }))
       .then(_ => createZip(`same bundle different versions`))

--- a/electrode-ota-server-routes-apps/src/index.js
+++ b/electrode-ota-server-routes-apps/src/index.js
@@ -1,12 +1,13 @@
-import Joi from 'joi';
-import { wrap, reqFields } from 'electrode-ota-server-util';
+/* eslint-disable max-params */
+import Joi from "joi";
+import { wrap, reqFields } from "electrode-ota-server-util";
 import diregister from "electrode-ota-server-diregister";
-const toAppOut = (src) => {
+const toAppOut = src => {
     const app = Object.assign({}, src);
     delete app.id;
     return app;
 };
-const noContent = (reply) => (e) => {
+const noContent = reply => e => {
     if (e) return reply(e);
     return reply().code(204);
 };
@@ -24,7 +25,7 @@ const toColab = (email, src) => {
     return app;
 };
 
-const toAppColab = (email) => (app) => toColab(email, toAppOut(app));
+const toAppColab = email => app => toColab(email, toAppOut(app));
 const PARAMS = {
     app: {
         app: Joi.string().required(true)
@@ -36,8 +37,8 @@ const PARAMS = {
 };
 
 export const register = diregister({
-    name: 'appsRoute',
-    dependencies: ['electrode:route', 'ota!app', 'ota!logger', 'ota!scheme']
+    name: "appsRoute",
+    dependencies: ["electrode:route", "ota!app", "ota!logger", "ota!scheme"]
 }, (options, route, app, logger) => {
     const {
         createApp,
@@ -70,8 +71,8 @@ export const register = diregister({
 
     route([
         {
-            method: 'POST',
-            path: '/apps/{app}/deployments/{deployment}/release',
+            method: "POST",
+            path: "/apps/{app}/deployments/{deployment}/release",
             config: {
                 validate: {
                     params: PARAMS.deployment
@@ -81,7 +82,7 @@ export const register = diregister({
                     logger.info(reqFields(request), "upload request ");
                     const {
                         params: { app, deployment }, auth: { credentials: { email } },
-                        server: { app: { config: { app: { downloadUrl = request.server.info.uri + '/storagev2/' } } } },
+                        server: { app: { config: { app: { downloadUrl = `${request.server.info.uri}/storagev2/` } } } },
                         payload
                     } = request;
                     payload.packageInfo = JSON.parse(payload.packageInfo);
@@ -94,8 +95,8 @@ export const register = diregister({
             }
         },
         {
-            method: 'PATCH',
-            path: '/apps/{app}/deployments/{deployment}/release',
+            method: "PATCH",
+            path: "/apps/{app}/deployments/{deployment}/release",
             config: {
                 validate: {
                     params: PARAMS.deployment
@@ -113,8 +114,8 @@ export const register = diregister({
             }
         },
         {
-            method: 'POST',
-            path: '/apps/',
+            method: "POST",
+            path: "/apps/",
             config: {
                 payload: Object.assign({}, options.payload),
                 handler(request, reply) {
@@ -129,8 +130,8 @@ export const register = diregister({
             }
         },
         {
-            method: 'GET',
-            path: '/apps',
+            method: "GET",
+            path: "/apps",
             config: {
                 handler(request, reply) {
                     logger.info(reqFields(request), "app list request");
@@ -143,8 +144,8 @@ export const register = diregister({
                 tags: ["api"]
             }
         }, {
-            method: 'GET',
-            path: '/apps/{app}',
+            method: "GET",
+            path: "/apps/{app}",
             config: {
                 validate: {
                     params: PARAMS.app
@@ -162,8 +163,8 @@ export const register = diregister({
             }
         },
         {
-            method: 'PATCH',
-            path: '/apps/{app}',
+            method: "PATCH",
+            path: "/apps/{app}",
             config: {
                 validate: {
                     params: PARAMS.app
@@ -179,8 +180,8 @@ export const register = diregister({
         },
 
         {
-            method: 'DELETE',
-            path: '/apps/{app}',
+            method: "DELETE",
+            path: "/apps/{app}",
             config: {
                 validate: {
                     params: PARAMS.app
@@ -194,24 +195,24 @@ export const register = diregister({
             }
         },
         {
-            method: 'POST',
-            path: '/apps/{app}/transfer/{transfer}',
+            method: "POST",
+            path: "/apps/{app}/transfer/{transfer}",
             config: {
                 payload: Object.assign({}, options.payload),
                 handler(request, reply) {
                     logger.info(reqFields(request), "transfer app request");
                     const { params: { app, transfer }, auth: { credentials: { email } } } = request;
-                    transferApp({ app, email, transfer }, (e) => {
+                    transferApp({ app, email, transfer }, e => {
                         if (e) return reply(e);
-                        return reply('Created').code(201);
+                        return reply("Created").code(201);
                     })
                 },
                 tags: ["api"]
             }
         },
         {
-            method: 'GET',
-            path: '/apps/{app}/deployments/',
+            method: "GET",
+            path: "/apps/{app}/deployments/",
             config: {
                 handler(request, reply) {
                     logger.info(reqFields(request), "get deployment list request");
@@ -226,8 +227,8 @@ export const register = diregister({
 
         },
         {
-            method: 'POST',
-            path: '/apps/{app}/deployments/',
+            method: "POST",
+            path: "/apps/{app}/deployments/",
             config: {
                 validate: {
                     params: PARAMS.app,
@@ -253,8 +254,8 @@ export const register = diregister({
 
         },
         {
-            method: 'PATCH',
-            path: '/apps/{app}/deployments/{deployment}',
+            method: "PATCH",
+            path: "/apps/{app}/deployments/{deployment}",
             config: {
                 validate: {
                     params: PARAMS.deployment,
@@ -273,8 +274,8 @@ export const register = diregister({
 
         },
         {
-            method: 'GET',
-            path: '/apps/{app}/deployments/{deployment}',
+            method: "GET",
+            path: "/apps/{app}/deployments/{deployment}",
             config: {
                 validate: {
                     params: PARAMS.deployment
@@ -295,8 +296,8 @@ export const register = diregister({
 
         },
         {
-            method: 'DELETE',
-            path: '/apps/{app}/deployments/{deployment}',
+            method: "DELETE",
+            path: "/apps/{app}/deployments/{deployment}",
             config: {
                 validate: {
                     params: PARAMS.deployment
@@ -311,8 +312,8 @@ export const register = diregister({
 
         },
         {
-            method: 'DELETE',
-            path: '/apps/{app}/deployments/{deployment}/history',
+            method: "DELETE",
+            path: "/apps/{app}/deployments/{deployment}/history",
             config: {
                 validate: {
                     params: PARAMS.deployment
@@ -326,8 +327,8 @@ export const register = diregister({
             }
 
         }, {
-            method: 'GET',
-            path: '/apps/{app}/deployments/{deployment}/history',
+            method: "GET",
+            path: "/apps/{app}/deployments/{deployment}/history",
             config: {
                 validate: {
                     params: PARAMS.deployment
@@ -345,8 +346,8 @@ export const register = diregister({
 
         },
         {
-            method: 'POST',
-            path: '/apps/{app}/deployments/{deployment}/promote/{to}',
+            method: "POST",
+            path: "/apps/{app}/deployments/{deployment}/promote/{to}",
             config: {
                 validate: {
                     params: Object.assign({ to: Joi.string() }, PARAMS.deployment)
@@ -364,11 +365,11 @@ export const register = diregister({
             }
         },
         {
-            method: 'POST',
-            path: '/apps/{app}/deployments/{deployment}/rollback/{label?}',
+            method: "POST",
+            path: "/apps/{app}/deployments/{deployment}/rollback/{label?}",
             config: {
                 validate: {
-                    params: Object.assign({ label: Joi.string().allow('') }, PARAMS.deployment)
+                    params: Object.assign({ label: Joi.string().allow("") }, PARAMS.deployment)
                 },
                 payload: Object.assign({}, options.payload),
                 handler(request, reply) {
@@ -384,8 +385,8 @@ export const register = diregister({
 
         },
         {
-            method: 'GET',
-            path: '/apps/{app}/deployments/{deployment}/metrics',
+            method: "GET",
+            path: "/apps/{app}/deployments/{deployment}/metrics",
             config: {
                 validate: {
                     params: PARAMS.deployment
@@ -395,7 +396,7 @@ export const register = diregister({
                     const { params: { app, deployment }, auth: { credentials: { email } } } = request;
                     metrics({ app, deployment, email }, (e, metrics) => {
                         if (e) {
-                            console.log('error in metrics', e);
+                            console.log("error in metrics", e);
                             return reply(e);
                         }
                         reply({ metrics });
@@ -403,11 +404,10 @@ export const register = diregister({
                 },
                 tags: ["api"]
             }
-        }
-        ,
+        },
         {
-            method: 'GET',
-            path: '/apps/{app}/collaborators',
+            method: "GET",
+            path: "/apps/{app}/collaborators",
             config: {
                 handler(request, reply) {
                     logger.info(reqFields(request), "get collaborators request");
@@ -431,8 +431,8 @@ export const register = diregister({
             }
         },
         {
-            method: 'POST',
-            path: '/apps/{app}/collaborators/{collaborator}',
+            method: "POST",
+            path: "/apps/{app}/collaborators/{collaborator}",
             config: {
                 payload: Object.assign({}, options.payload),
                 handler(request, reply) {
@@ -440,15 +440,15 @@ export const register = diregister({
                     const { params: { app, collaborator }, auth: { credentials: { email } } } = request;
                     addCollaborator({ email, app, collaborator }, (e, o) => {
                         if (e) return reply(e);
-                        return reply('Created').code(201);
+                        return reply("Created").code(201);
                     });
                 },
                 tags: ["api"]
             }
         },
         {
-            method: 'DELETE',
-            path: '/apps/{app}/collaborators/{collaborator}',
+            method: "DELETE",
+            path: "/apps/{app}/collaborators/{collaborator}",
             config: {
                 handler(request, reply) {
                     logger.info(reqFields(request), "remove collaborator request");

--- a/electrode-ota-server-routes-auth/src/index.js
+++ b/electrode-ota-server-routes-auth/src/index.js
@@ -1,15 +1,16 @@
-import { wrap, reqFields } from 'electrode-ota-server-util';
+import { wrap, reqFields } from "electrode-ota-server-util";
 import diregister from "electrode-ota-server-diregister";
 
 export const register = diregister({
-    name: 'authRoute',
-    dependencies: ['electrode:route', 'ota!account', 'electrode:views', 'ota!scheme', 'ota!logger'],
+    name: "authRoute",
+    dependencies: ["electrode:route", "ota!account", "electrode:views", "ota!scheme", "ota!logger"]
+    // eslint-disable-next-line max-params
 }, (options, route, acf, views, scheme, logger) => {
 
     views({
-        engines: options.engines || {ejs: require('ejs')},
+        engines: options.engines || {ejs: require("ejs")},
         relativeTo: options.relativeTo || __dirname,
-        path: options.path || '../templates',
+        path: options.path || "../templates",
         layout: options.layout === false ? false : true
     });
 
@@ -28,7 +29,9 @@ export const register = diregister({
      *    displayName : display name of user,
      *    createdBy : description of how the access was created
      * }
-     * @param {credentials} credentials 
+     * @param {object} credentials auth credential object
+     * @param {object} reply response method
+     * @returns {object} auth credential object
      */
     const _normalizeCredentials = (credentials, reply) => {
         if (credentials.profile) {
@@ -48,23 +51,23 @@ export const register = diregister({
                 }
             };
         } else {
-            return reply.view('error', {
-                title: 'Unmapped credentials',
-                message: 'Authentication Creditials is not properly formatted'
+            return reply.view("error", {
+                title: "Unmapped credentials",
+                message: "Authentication Creditials is not properly formatted"
             });
         }
     };
 
     route([
         {
-            method: 'GET',
-            path: '/auth/{type}',
+            method: "GET",
+            path: "/auth/{type}",
             config: {
                 auth: false,
-                handler(req, reply){
+                handler(req, reply) {
                     logger.info(reqFields(req), "auth request");
-                    reply.view('login', {
-                        title: 'Login',
+                    reply.view("login", {
+                        title: "Login",
                         providers: options.providers,
                         hostname: req.query.hostname,
                         type: req.params.type
@@ -72,8 +75,8 @@ export const register = diregister({
                 }
             }
         }, {
-            method: 'GET',
-            path: '/accesskey',
+            method: "GET",
+            path: "/accesskey",
             config: {
                 auth: {
                     mode: "try",
@@ -87,11 +90,11 @@ export const register = diregister({
                         }, reply) {
 
                     if (!isAuthenticated) {
-                        return reply.redirect('/auth/login').code(302);
+                        return reply.redirect("/auth/login").code(302);
                     }
                     cookieAuth && cookieAuth.clear();
-                    reply.view('accesskey', {
-                        title: 'Token',
+                    reply.view("accesskey", {
+                        title: "Token",
                         name: credentials.name
                     });
                 }
@@ -100,51 +103,52 @@ export const register = diregister({
 
 
         {
-            method: 'GET',
-            path: '/',
+            method: "GET",
+            path: "/",
             config: {
                 auth: false,
-                handler(request, reply){
-                    reply.redirect('/auth/login').code(302);
+                handler(request, reply) {
+                    reply.redirect("/auth/login").code(302);
                 }
             }
         },
         {
-            method: 'GET',
-            path: '/authenticated',
+            method: "GET",
+            path: "/authenticated",
             config: {
                 auth: {
                     strategy: "bearer",
-                    mode: 'try'
+                    mode: "try"
                 },
-                handler(request, reply){
+                handler(request, reply) {
                     reply({
-                        "authenticated": request.auth.isAuthenticated
+                        authenticated: request.auth.isAuthenticated
                     });
                 }
             }
         }, {
-            method: 'GET',
-            path: '/logout',
+            method: "GET",
+            path: "/logout",
             config: {
-                auth: {mode: 'optional', strategies: ['session', 'bearer']},
+                auth: {mode: "optional", strategies: ["session", "bearer"]},
                 handler(request, reply) {
-                    invalidate(request.auth.credentials && request.auth.credentials.name, (e) => {
+                    invalidate(request.auth.credentials && request.auth.credentials.name, e => {
                         if (e) {
-                            console.log('error logging out', e);
+                            // eslint-disable-next-line no-console
+                            console.log("error logging out", e);
                         }
                         request.cookieAuth && request.cookieAuth.clear();
-                        reply.redirect('/');
+                        reply.redirect("/");
                     });
                 }
             }
         },
         {
-            method: 'DELETE',
-            path: '/sessions/{session}',
+            method: "DELETE",
+            path: "/sessions/{session}",
             config: {
-                auth: {mode: 'required'},
-                handler(request, reply){
+                auth: {mode: "required"},
+                handler(request, reply) {
                     invalidate(request.cookieAuth.token, () => {
                         request.cookieAuth.clear();
                         reply();
@@ -160,12 +164,12 @@ export const register = diregister({
                                       loginPath,
                                       registerPath,
                                       linkPath,
-                                      redirectTo = '/accesskey'
+                                      redirectTo = "/accesskey"
                                   }) => {
             const strategy = auth || name;
             loginPath = loginPath || `/auth/login/${name}`;
             ret.push({
-                method: 'GET',
+                method: "GET",
                 path: loginPath,
                 config: {
                     auth: {
@@ -174,7 +178,7 @@ export const register = diregister({
                     },
                     handler ({auth: {isAuthenticated, credentials}, cookieAuth}, reply) {
                         if (!isAuthenticated) {
-                            return reply('Not logged in...').code(401);
+                            return reply("Not logged in...").code(401);
                         }
                         if (credentials) {
                            const mappedCredential = _normalizeCredentials(credentials, reply);
@@ -183,17 +187,17 @@ export const register = diregister({
                             //(email, createdBy, friendlyName, ttl
                             addAccessKey(email, hostname, displayName || username, void(0), (e, token) => {
                                 if (e) {
-                                    let message = 'Error adding access key';
-                                    let href = '';
-                                    if (e.message.indexOf('No user registered') >= 0) {
+                                    let message = "Error adding access key";
+                                    let href = "";
+                                    if (e.message.indexOf("No user registered") >= 0) {
                                         message = e.message + " Try using 'code-push register' instead of 'code-push login'";
                                         if (registerPath !== false) {
                                             href = registerPath;
                                             message += ", or click here to register."
                                         }
                                     }
-                                    return reply.view('error', {
-                                        title: 'Error adding accesskey',
+                                    return reply.view("error", {
+                                        title: "Error adding accesskey",
                                         message,
                                         href
                                     });
@@ -210,30 +214,32 @@ export const register = diregister({
             if (registerPath !== false) {
                 registerPath = registerPath || `/auth/register/${name}`;
                 ret.push({
-                    method: 'GET',
+                    method: "GET",
                     path: registerPath,
                     config: {
                         auth: strategy,
                         handler ({auth: {isAuthenticated, credentials}, cookieAuth}, reply) {
                             if (!isAuthenticated) {
-                                console.error('request was not authenticated');
-                                return reply('Not logged in...').code(401);
+                                // eslint-disable-next-line no-console
+                                console.error("request was not authenticated");
+                                return reply("Not logged in...").code(401);
                             }
                             const mappedCredential = _normalizeCredentials(credentials, reply);
-                            createToken(mappedCredential).then((token) => {
+                            createToken(mappedCredential).then(token => {
                                 cookieAuth.set({ token : token.name });
                                 reply.redirect(redirectTo).code(302);
-                            }).catch((e) => {
-                                if (e.output && e.output.payload && e.output.payload.error === 'Conflict') {
-                                    return reply.view('error', {
-                                        title: 'Error adding account',
-                                        message: 'This account is already registered. Click here to log in instead.',
+                            }).catch(e => {
+                                if (e.output && e.output.payload && e.output.payload.error === "Conflict") {
+                                    return reply.view("error", {
+                                        title: "Error adding account",
+                                        message: "This account is already registered. Click here to log in instead.",
                                         href: `/auth/login?hostname=${credentials.query && credentials.query.hostname}`
                                     })
                                 }
-                                console.error('Error creating token', e);
-                                return reply.view('error', {
-                                    title: 'Error adding account',
+                                // eslint-disable-next-line no-console
+                                console.error("Error creating token", e);
+                                return reply.view("error", {
+                                    title: "Error adding account",
                                     message: e.message
                                 });
                             });
@@ -242,23 +248,24 @@ export const register = diregister({
                 });
                 linkPath = linkPath || `/auth/link/${name}`;
                 ret.push({
-                    method: 'GET',
+                    method: "GET",
                     path: linkPath,
                     config: {
                         auth: strategy,
                         handler ({auth: {isAuthenticated, credentials}}, reply) {
                             if (!isAuthenticated) {
-                                console.error('request was not authenticated');
-                                return reply('Not logged in...').code(401);
+                                // eslint-disable-next-line no-console
+                                console.error("request was not authenticated");
+                                return reply("Not logged in...").code(401);
                             }
                             if (credentials) {
                                 const mappedCredential = _normalizeCredentials(credentials, reply);
                                 const {email} = mappedCredential.profile;
-                                linkProvider({email, provider: name}, (e) => {
+                                linkProvider({email, provider: name}, e => {
                                     if (e) {
-                                        return reply.view('error', {title: 'Error', message: e.message});
+                                        return reply.view("error", {title: "Error", message: e.message});
                                     }
-                                    reply.view('link', {
+                                    reply.view("link", {
                                         title: `Linked to ${name}`,
                                         provider: name
                                     });

--- a/package.json
+++ b/package.json
@@ -31,14 +31,14 @@
     "cordova"
   ],
   "dependencies": {
-    "lerna": "^3.20.2",
+    "lerna": "^2.0.0-rc.2",
     "lerna-relinker": "^1.2.2"
   },
   "devDependencies": {
     "babel-cli": "^6.24.1",
     "babel-core": "^6.24.1",
     "babel-eslint": "^8.1.2",
-    "babel-plugin-istanbul": "^6.0.0",
+    "babel-plugin-istanbul": "^4.1.1",
     "babel-plugin-syntax-async-functions": "^6.13.0",
     "babel-plugin-transform-async-to-generator": "^6.24.1",
     "babel-plugin-transform-class-properties": "^6.24.1",
@@ -57,8 +57,8 @@
     "eslint-plugin-prettier": "^2.4.0",
     "eslint-plugin-promise": "^3.6.0",
     "eslint-plugin-standard": "^3.0.1",
-    "mocha": "^7.0.1",
-    "nyc": "^15.0.0",
+    "mocha": "^2.5.3",
+    "nyc": "^10.2.0",
     "rimraf": "^2.5.4",
     "supertest": "^2.0.0",
     "tmp": "0.0.29"

--- a/package.json
+++ b/package.json
@@ -31,14 +31,14 @@
     "cordova"
   ],
   "dependencies": {
-    "lerna": "^2.0.0-rc.2",
+    "lerna": "^3.20.2",
     "lerna-relinker": "^1.2.2"
   },
   "devDependencies": {
     "babel-cli": "^6.24.1",
     "babel-core": "^6.24.1",
     "babel-eslint": "^8.1.2",
-    "babel-plugin-istanbul": "^4.1.1",
+    "babel-plugin-istanbul": "^6.0.0",
     "babel-plugin-syntax-async-functions": "^6.13.0",
     "babel-plugin-transform-async-to-generator": "^6.24.1",
     "babel-plugin-transform-class-properties": "^6.24.1",
@@ -57,8 +57,8 @@
     "eslint-plugin-prettier": "^2.4.0",
     "eslint-plugin-promise": "^3.6.0",
     "eslint-plugin-standard": "^3.0.1",
-    "mocha": "^2.5.3",
-    "nyc": "^10.2.0",
+    "mocha": "^7.0.1",
+    "nyc": "^15.0.0",
     "rimraf": "^2.5.4",
     "supertest": "^2.0.0",
     "tmp": "0.0.29"


### PR DESCRIPTION
When deploying a new app, they NEED real-time data to monitor for bad versions.  This usually occurs in the first 10 minutes or so.

Taking  the summation of the last time it's summed, query the database for the remaining real-time data. This query should be quick because it is time-bound. 

If the last summed time is > than 1 day, query only for 1 day's worth of data.