### PR TITLE
temp api to download packages to validate proxy cache

### DIFF
--- a/electrode-ota-server-routes-acquisition/src/index.js
+++ b/electrode-ota-server-routes-acquisition/src/index.js
@@ -86,6 +86,24 @@ export const register = diregister({
                         if (e) return reply(e);
                         const { content, length } = o;
                         reply(content)
+                            .type("application/octet-stream")
+                            .bytes(length);
+                    });
+                },
+                tags: ["api"]
+            }
+        },
+        {
+            path: "/foo_getp/{packageHash}",
+            method: "GET",
+            config: {
+                auth: false,
+                handler(request, reply) {
+                    logger.info(reqFields(request), "download request");
+                    download(request.params.packageHash, (e, o) => {
+                        if (e) return reply(e);
+                        const { content, length } = o;
+                        reply(content)
                             .header("Cache-Control", "s-maxage=31536000, max-age=0")
                             .type("application/octet-stream")
                             .bytes(length);


### PR DESCRIPTION
`/foo_getp/{hash}` sends standard cache-control header to enable caching in proxy(Edgecast)
It's a temporary api to validate the caching.
It's not exposed anywhere.

Existing `/storagev2/{hash}` will not send any cache-control headers.