### PR TITLE
fix real-time metrics query and add ccm to control it

### DIFF
--- a/electrode-ota-server-dao-mariadb/src/ElectrodeOtaDaoRdbms.ts
+++ b/electrode-ota-server-dao-mariadb/src/ElectrodeOtaDaoRdbms.ts
@@ -299,6 +299,12 @@ export default class ElectrodeOtaDaoRdbms implements IElectrodeOtaDao {
         })
     }
 
+    public async metricsByStatusAfterSpecificTime(deploymentKey: string, specificDateUTC: Date): Promise<MetricByStatusOutDTO[]> {
+        return this.connectAndExecute((connection) => {
+            return MetricDAO.metricsByStatusAfterSpecificTime(connection, deploymentKey, specificDateUTC);
+        })
+    }
+
     public async getMetricSummary(deploymentKey: string): Promise<MetricSummaryDTO | undefined> {
         return this.connectAndExecute((connection) => {
             return MetricSummaryDAO.getMetricSummary(connection, deploymentKey);

--- a/electrode-ota-server-dao-mariadb/src/dao/MetricDAO.ts
+++ b/electrode-ota-server-dao-mariadb/src/dao/MetricDAO.ts
@@ -83,4 +83,24 @@ export default class MetricDAO extends BaseDAO {
             return dto;
         });
     }
+
+    public static async metricsByStatusAfterSpecificTime(connection: IConnection, deploymentKey: string, specificDate: Date): Promise<MetricByStatusOutDTO[]> {
+        const depResults = await MetricDAO.query(connection, DeploymentQueries.getDeploymentByKey, [deploymentKey]);
+
+        if (!depResults || depResults.length === 0) {
+            throw new Error("Not found. no deployment found for key [" + deploymentKey + "]");
+        }
+        const metricResults = await MetricDAO.query(connection, MetricQueries.getMetricsByStatusAfterSpecificTime, [depResults[0].id, specificDate]);
+        return metricResults.map((result: any) => {
+            const dto = new MetricByStatusOutDTO();
+            dto.deploymentkey = deploymentKey;
+            dto.appversion = result.app_version;
+            dto.label = result.label;
+            dto.status = result.status;
+            dto.previousdeploymentkey = result.previous_deployment_key;
+            dto.previouslabelorappversion = result.previous_label_or_app_version;
+            dto.total = result.total;
+            return dto;
+        });
+    }
 }

--- a/electrode-ota-server-dao-mariadb/src/queries/MetricQueries.ts
+++ b/electrode-ota-server-dao-mariadb/src/queries/MetricQueries.ts
@@ -23,4 +23,8 @@ export const MetricQueries = {
                     previous_deployment_key, previous_label_or_app_version, status)
                     VALUES(?, ?, ?, ?,
                     ?, ?, ?)`,
+
+    getMetricsByStatusAfterSpecificTime : `SELECT count(*) as total, app_version, label, previous_deployment_key,
+                    previous_label_or_app_version, status FROM metric WHERE deployment_id = ? AND create_time >= ?
+                    GROUP BY status, label, app_version, previous_deployment_key, previous_label_or_app_version`,
 };

--- a/electrode-ota-server-dao-mariadb/test/ElectrodeOtaDaoRdms-spec.ts
+++ b/electrode-ota-server-dao-mariadb/test/ElectrodeOtaDaoRdms-spec.ts
@@ -1649,7 +1649,6 @@ describe("Data Access via RDBMS", function() {
 
     describe("history-related methods", () => {
       describe("history", () => {
-        
         it("will throw an error if app not found", () => {
           return dao.history(-100, "stuff").catch(err => {
             expect(err).not.to.be.undefined;
@@ -2052,6 +2051,34 @@ describe("Data Access via RDBMS", function() {
               return dao.metricsByStatusAndTime(metricDeploymentKey, midTime, endTime);
             }).then(metrics => {
               expect(metrics.length).eq(4);
+            });
+        });
+
+        it("fetch summary of metrics by status, after given specific time", () => {
+          const metricData = [
+            { label: "v1", appVersion: "1.0.0", status:"DeploymentSucceeded"},
+            { label: "v1", appVersion: "1.0.0", status:"Downloaded"},
+            { label: "v2", appVersion: "1.2.0", status:"Downloaded"},
+            { label: "v2", appVersion: "1.2.5", status:"DeploymentFailed"},
+            { label: "v3", appVersion: "1.3.0", status:"DeploymentFailed"},
+            { label: "v3", appVersion: "1.3.5", status:"Downloaded"}
+          ]
+          let phase1 = createMetricInDTOs(metricDeploymentKey, metricData.slice(0,2));
+          let phase2 = createMetricInDTOs(metricDeploymentKey, metricData.slice(2,6));
+
+          const startTime = new Date(Date.now() - 1000);
+          return Promise.all(phase1.map(d => dao.insertMetric(d)))
+            .then(() => {
+              return new Promise(resolve => setTimeout(resolve, 2000));
+            })
+            .then(() => {
+              return Promise.all(phase2.map(d => dao.insertMetric(d)));
+            })
+            .then(() => {
+              return dao.metricsByStatusAfterSpecificTime(metricDeploymentKey, startTime)
+            })
+            .then(metrics => {
+              expect(metrics.length).eq(6);
             });
         });
       });

--- a/electrode-ota-server-model-app/src/app.js
+++ b/electrode-ota-server-model-app/src/app.js
@@ -598,7 +598,7 @@ export default (options, dao, upload, logger, ccm) => {
         if (result && result.summaryJson) {
           const summary = JSON.parse(result.summaryJson);
           const doRealTimeMetrics = ccm("doRealTimeMetrics");
-          if (doRealTimeMetrics) {
+          if (doRealTimeMetrics === "true") {
             // fetch latest real-time metrics
             return dao.metricsByStatusAfterSpecificTime(deployment.key, result.lastRunTimeUTC)
             .then((metrics = []) => {

--- a/electrode-ota-server-model-app/src/index.js
+++ b/electrode-ota-server-model-app/src/index.js
@@ -5,5 +5,5 @@ export const register = diregister({
     name: 'ota!app',
     multiple: false,
     connections: false,
-    dependencies: ['ota!dao', 'ota!fileservice-upload', 'ota!logger']
+    dependencies: ['ota!dao', 'ota!fileservice-upload', 'ota!logger', 'ota!ccm']
 }, app);

--- a/electrode-ota-server-model-app/test/app-test.js
+++ b/electrode-ota-server-model-app/test/app-test.js
@@ -33,6 +33,9 @@ let metricSummaryApp = {
   email: "cached_summary@walmart.com",
   deploymentType: "Staging"
 };
+// simulate ccm
+const ccm = () => true;
+
 
 describe("model/app", function() {
   this.timeout(50000);
@@ -65,7 +68,7 @@ describe("model/app", function() {
     let w = 0;
     account = accountFactory({}, dao, console);
     const up = upload({}, dao);
-    ac = appFactory({}, dao, up, console);
+    ac = appFactory({}, dao, up, console, ccm);
     await createAccount(APP.email, "test");
   });
 

--- a/electrode-ota-server-model-app/test/app-test.js
+++ b/electrode-ota-server-model-app/test/app-test.js
@@ -34,7 +34,7 @@ let metricSummaryApp = {
   deploymentType: "Staging"
 };
 // simulate ccm
-const ccm = () => true;
+const ccm = () => "true";
 
 
 describe("model/app", function() {


### PR DESCRIPTION
retrieving real-time metrics by time range fails if used timestamp
1. converting `create_time` to timestamp using `UNIX_TIMESTAMP()` in each record takes more time.
2. simple date comparison `create_time >= '2020-04-20 19:01:00'` yields results.

added ccm config(`doRealTimeMetrics`) to control real-time data fetch, so that it can be turned off if not required.